### PR TITLE
Fix un-translated indicator names

### DIFF
--- a/meta/1-3-1-a.md
+++ b/meta/1-3-1-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of registered disabled people to the total number of population
-  at the end of the year
+graph_title: meta.name-1-3-1-a
 graph_type: line
 indicator: 1.3.1.a
-indicator_name: Proportion of registered disabled people to the total number of population
-  at the end of the year
+indicator_name: meta.name-1-3-1-a
 indicator_sort_order: 01-03-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-b.md
+++ b/meta/1-3-1-b.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Children with disabilities from diseases (aged 0-17 years)
+graph_title: meta.name-1-3-1-b
 graph_type: line
 indicator: 1.3.1.b
-indicator_name: Children with disabilities from diseases (aged 0-17 years)
+indicator_name: meta.name-1-3-1-b
 indicator_sort_order: 01-03-01-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-c.md
+++ b/meta/1-3-1-c.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of pensioners to the total number of population at the end
-  of the year
+graph_title: meta.name-1-3-1-c
 graph_type: line
 indicator: 1.3.1.c
-indicator_name: Proportion of pensioners to the total number of population at the
-  end of the year
+indicator_name: meta.name-1-3-1-c
 indicator_sort_order: 01-03-01-0c
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-d.md
+++ b/meta/1-3-1-d.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Ratio of elderly pensioners.               Ratio of age pensioners and
-  the retirement age stipulated by law and aged population
+graph_title: meta.name-1-3-1-d
 graph_type: line
 indicator: 1.3.1.d
-indicator_name: Ratio of elderly pensioners.               Ratio of age pensioners
-  and the retirement age stipulated by law and aged population
+indicator_name: meta.name-1-3-1-d
 indicator_sort_order: 01-03-01-0d
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-e.md
+++ b/meta/1-3-1-e.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of families receiving family benefits to households
+graph_title: meta.name-1-3-1-e
 graph_type: line
 indicator: 1.3.1.e
-indicator_name: Proportion of families receiving family benefits to households
+indicator_name: meta.name-1-3-1-e
 indicator_sort_order: 01-03-01-0e
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-f.md
+++ b/meta/1-3-1-f.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of families receiving social benefits to households
+graph_title: meta.name-1-3-1-f
 graph_type: line
 indicator: 1.3.1.f
-indicator_name: Proportion of families receiving social benefits to households
+indicator_name: meta.name-1-3-1-f
 indicator_sort_order: 01-03-01-0f
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-g.md
+++ b/meta/1-3-1-g.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of beneficiaries of old age, disability and in case of losing
-  a breadwinner to the total number of population at the end of the year
+graph_title: meta.name-1-3-1-g
 graph_type: line
 indicator: 1.3.1.g
-indicator_name: Proportion of beneficiaries of old age, disability and in case of
-  losing a breadwinner to the total number of population at the end of the year
+indicator_name: meta.name-1-3-1-g
 indicator_sort_order: 01-03-01-0g
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-h.md
+++ b/meta/1-3-1-h.md
@@ -1,10 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Children of orphans (aged 0-17 years) at the end of the year
+graph_title: meta.name-1-3-1-h
 graph_type: line
 indicator: 1.3.1.h
-indicator_name: Children of orphans (aged 0-17 years) at the end of the year
+indicator_name: meta.name-1-3-1-h
 indicator_sort_order: 01-03-01-0h
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-i.md
+++ b/meta/1-3-1-i.md
@@ -1,10 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Children who return to relatives from orphanages (aged 0-17 years)
+graph_title: meta.name-1-3-1-i
 graph_type: line
 indicator: 1.3.1.i
-indicator_name: Children who return to relatives from orphanages (aged 0-17 years)
+indicator_name: meta.name-1-3-1-i
 indicator_sort_order: 01-03-01-0i
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-j.md
+++ b/meta/1-3-1-j.md
@@ -1,12 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Children with disabilities living in orphanages (aged 0-17 years) at
-  the end of the year
+graph_title: meta.name-1-3-1-j
 graph_type: line
 indicator: 1.3.1.j
-indicator_name: Children with disabilities living in orphanages (aged 0-17 years)
-  at the end of the year
+indicator_name: meta.name-1-3-1-j
 indicator_sort_order: 01-03-01-0j
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-ja.md
+++ b/meta/1-3-1-ja.md
@@ -1,10 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Adopted children (aged 0-17 years)
+graph_title: meta.name-1-3-1-ja
 graph_type: line
 indicator: 1.3.1.ja
-indicator_name: Adopted children (aged 0-17 years)
+indicator_name: meta.name-1-3-1-ja
 indicator_sort_order: 01-03-01-ja
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-jb.md
+++ b/meta/1-3-1-jb.md
@@ -1,10 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Adopted children by social groups (aged 0-17 years)
+graph_title: meta.name-1-3-1-jb
 graph_type: line
 indicator: 1.3.1.jb
-indicator_name: Adopted children by social groups (aged 0-17 years)
+indicator_name: meta.name-1-3-1-jb
 indicator_sort_order: 01-03-01-jb
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-3-1-jc.md
+++ b/meta/1-3-1-jc.md
@@ -1,12 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Number of beneficiaries receiving maternity benefits granted to non-employed
-  person at the end of the year
+graph_title: meta.name-1-3-1-jc
 graph_type: line
 indicator: 1.3.1.jc
-indicator_name: Number of beneficiaries receiving maternity benefits granted to non-employed
-  person at the end of the year
+indicator_name: meta.name-1-3-1-jc
 indicator_sort_order: 01-03-01-jc
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-4-1-a.md
+++ b/meta/1-4-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Centralized water supply
+graph_title: meta.name-1-4-1-a
 graph_type: line
 indicator: 1.4.1.a
-indicator_name: Centralized water supply
+indicator_name: meta.name-1-4-1-a
 indicator_sort_order: 01-04-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-4-1-b.md
+++ b/meta/1-4-1-b.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Centralized sewerage system
+graph_title: meta.name-1-4-1-b
 graph_type: line
 indicator: 1.4.1.b
-indicator_name: Centralized sewerage system
+indicator_name: meta.name-1-4-1-b
 indicator_sort_order: 01-04-01-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/1-5-1-a.md
+++ b/meta/1-5-1-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: per 100,000 population
 data_non_statistical: false
-graph_title: Number of deaths,  temporarily evacuated and directly affected persons
-  attributed to disasters per 100,000 population  by types of disasters
+graph_title: meta.name-1-5-1-a
 graph_type: line
 indicator: 1.5.1.a
-indicator_name: Number of deaths,  temporarily evacuated and directly affected persons
-  attributed to disasters per 100,000 population  by types of disasters
+indicator_name: meta.name-1-5-1-a
 indicator_sort_order: 01-05-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/10-7-2-a.md
+++ b/meta/10-7-2-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Percentage of returned migrants who undertook paid work during the last
-  7 days
+graph_title: meta.name-10-7-2-a
 graph_type: line
 indicator: 10.7.2.a
-indicator_name: Percentage of returned migrants who undertook paid work during the
-  last 7 days
+indicator_name: meta.name-10-7-2-a
 indicator_sort_order: 10-07-02-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/10-7-2-b.md
+++ b/meta/10-7-2-b.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of individual asylum applications granted
+graph_title: meta.name-10-7-2-b
 graph_type: line
 indicator: 10.7.2.b
-indicator_name: Proportion of individual asylum applications granted
+indicator_name: meta.name-10-7-2-b
 indicator_sort_order: 10-07-02-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/11-5-1-a.md
+++ b/meta/11-5-1-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: per 100,000 population
 data_non_statistical: false
-graph_title: Number of deaths,  temporarily evacuated and directly affected persons
-  attributed to disasters per 100,000 population  by types of disasters
+graph_title: meta.name-11-5-1-a
 graph_type: line
 indicator: 11.5.1.a
-indicator_name: Number of deaths,  temporarily evacuated and directly affected persons
-  attributed to disasters per 100,000 population  by types of disasters
+indicator_name: meta.name-11-5-1-a
 indicator_sort_order: 11-05-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/12-3-1-a.md
+++ b/meta/12-3-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: thousand tons
 data_non_statistical: false
-graph_title: Food loss
+graph_title: meta.name-12-3-1-a
 graph_type: line
 indicator: 12.3.1.a
-indicator_name: Food loss
+indicator_name: meta.name-12-3-1-a
 indicator_sort_order: 12-03-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/13-1-1-a.md
+++ b/meta/13-1-1-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: per 100,000 population
 data_non_statistical: false
-graph_title: Number of deaths,  temporarily evacuated and directly affected persons
-  attributed to disasters per 100,000 population  by types of disasters
+graph_title: meta.name-13-1-1-a
 graph_type: line
 indicator: 13.1.1.a
-indicator_name: Number of deaths,  temporarily evacuated and directly affected persons
-  attributed to disasters per 100,000 population  by types of disasters
+indicator_name: meta.name-13-1-1-a
 indicator_sort_order: 13-01-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/14-3-1-a.md
+++ b/meta/14-3-1-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: mole - H - ion / liter
 data_non_statistical: false
-graph_title: Average Lake Sevan acidity (pH) measured at agreed suite of representative
-  sampling stations
+graph_title: meta.name-14-3-1-a
 graph_type: line
 indicator: 14.3.1.a
-indicator_name: Average Lake Sevan acidity (pH) measured at agreed suite of representative
-  sampling stations
+indicator_name: meta.name-14-3-1-a
 indicator_sort_order: 14-03-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/14-5-1-a.md
+++ b/meta/14-5-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Coverage of protected water areas in relation to lakes and reservoirs
+graph_title: meta.name-14-5-1-a
 graph_type: line
 indicator: 14.5.1.a
-indicator_name: Coverage of protected water areas in relation to lakes and reservoirs
+indicator_name: meta.name-14-5-1-a
 indicator_sort_order: 14-05-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/14-a-1-a.md
+++ b/meta/14-a-1-a.md
@@ -1,11 +1,10 @@
 ---
 computation_units: mln.drams
 data_non_statistical: false
-graph_title: Budget allocated to research and complex protection related to lake Sevan
+graph_title: meta.name-14-a-1-a
 graph_type: line
 indicator: 14.a.1.a
-indicator_name: Budget allocated to research and complex protection related to lake
-  Sevan
+indicator_name: meta.name-14-a-1-a
 indicator_sort_order: 14-0a-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/15-5-1-a-1.md
+++ b/meta/15-5-1-a-1.md
@@ -1,10 +1,10 @@
 ---
 computation_units: units
 data_non_statistical: false
-graph_title: Registered vertebrate and invertebrate species, of which
+graph_title: meta.name-15-5-1-a-1
 graph_type: line
 indicator: 15.5.1.a.1
-indicator_name: Registered vertebrate and invertebrate species, of which
+indicator_name: meta.name-15-5-1-a-1
 indicator_sort_order: 15-05-01-0a-01
 national_geographical_coverage: Armenia
 published: true

--- a/meta/15-5-1-a-2.md
+++ b/meta/15-5-1-a-2.md
@@ -1,10 +1,10 @@
 ---
 computation_units: units
 data_non_statistical: false
-graph_title: Registered high and low plant species, of which
+graph_title: meta.name-15-5-1-a-2
 graph_type: line
 indicator: 15.5.1.a.2
-indicator_name: Registered high and low plant species, of which
+indicator_name: meta.name-15-5-1-a-2
 indicator_sort_order: 15-05-01-0a-02
 national_geographical_coverage: Armenia
 published: true

--- a/meta/16-1-1-a.md
+++ b/meta/16-1-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: per 100, 000 population
 data_non_statistical: false
-graph_title: Number of homicide cases per 100,000 population
+graph_title: meta.name-16-1-1-a
 graph_type: line
 indicator: 16.1.1.a
-indicator_name: Number of homicide cases per 100,000 population
+indicator_name: meta.name-16-1-1-a
 indicator_sort_order: 16-01-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/17-1-1-a.md
+++ b/meta/17-1-1-a.md
@@ -1,11 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Total central government revenue as a proportion of GDP, by source, including
+graph_title: meta.name-17-1-1-a
 graph_type: line
 indicator: 17.1.1.a
-indicator_name: Total central government revenue as a proportion of GDP, by source,
-  including
+indicator_name: meta.name-17-1-1-a
 indicator_sort_order: 17-01-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/17-3-1-a.md
+++ b/meta/17-3-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: mln. USD
 data_non_statistical: false
-graph_title: Foreign direct investments (FDI)
+graph_title: meta.name-17-3-1-a
 graph_type: line
 indicator: 17.3.1.a
-indicator_name: Foreign direct investments (FDI)
+indicator_name: meta.name-17-3-1-a
 indicator_sort_order: 17-03-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/17-4-1-a.md
+++ b/meta/17-4-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: External debt service as percentage of exports goods and services
+graph_title: meta.name-17-4-1-a
 graph_type: line
 indicator: 17.4.1.a
-indicator_name: External debt service as percentage of exports goods and services
+indicator_name: meta.name-17-4-1-a
 indicator_sort_order: 17-04-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-1-1-a.md
+++ b/meta/3-1-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: per 100,000 live births
 data_non_statistical: false
-graph_title: Maternal mortality ratio (average three-year indicator)
+graph_title: meta.name-3-1-1-a
 graph_type: line
 indicator: 3.1.1.a
-indicator_name: Maternal mortality ratio (average three-year indicator)
+indicator_name: meta.name-3-1-1-a
 indicator_sort_order: 03-01-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-2-2-a.md
+++ b/meta/3-2-2-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: per 1000 life births
 data_non_statistical: false
-graph_title: Infant mortality rate
+graph_title: meta.name-3-2-2-a
 graph_type: line
 indicator: 3.2.2.a
-indicator_name: Infant mortality rate
+indicator_name: meta.name-3-2-2-a
 indicator_sort_order: 03-02-02-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-1-a.md
+++ b/meta/3-3-1-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: per 1000 uninfected population
 data_non_statistical: false
-graph_title: HIV infection transmission from HIV-infected mothers with non-breastfeeding
-  to child
+graph_title: meta.name-3-3-1-a
 graph_type: line
 indicator: 3.3.1.a
-indicator_name: HIV infection transmission from HIV-infected mothers with non-breastfeeding
-  to child
+indicator_name: meta.name-3-3-1-a
 indicator_sort_order: 03-03-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-1-b.md
+++ b/meta/3-3-1-b.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Percentage of people living with HIV, who know their  status
+graph_title: meta.name-3-3-1-b
 graph_type: line
 indicator: 3.3.1.b
-indicator_name: Percentage of people living with HIV, who know their  status
+indicator_name: meta.name-3-3-1-b
 indicator_sort_order: 03-03-01-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-1-c.md
+++ b/meta/3-3-1-c.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Percentage of people living with HIV, who know their  status, who receive
-  ARV treatment
+graph_title: meta.name-3-3-1-c
 graph_type: line
 indicator: 3.3.1.c
-indicator_name: Percentage of people living with HIV, who know their  status, who
-  receive ARV treatment
+indicator_name: meta.name-3-3-1-c
 indicator_sort_order: 03-03-01-0c
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-1-d.md
+++ b/meta/3-3-1-d.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Percentage of HIV patients, who receive ARV   treatment, who have unrecognized
-  level of viral load (VL)
+graph_title: meta.name-3-3-1-d
 graph_type: line
 indicator: 3.3.1.d
-indicator_name: Percentage of HIV patients, who receive ARV   treatment, who have
-  unrecognized level of viral load (VL)
+indicator_name: meta.name-3-3-1-d
 indicator_sort_order: 03-03-01-0d
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-2-a.md
+++ b/meta/3-3-2-a.md
@@ -1,11 +1,10 @@
 ---
 computation_units: per 100,000 population
 data_non_statistical: false
-graph_title: Multi-drug resistant tuberculosis morbidity indicator (per 100,000 population)
+graph_title: meta.name-3-3-2-a
 graph_type: line
 indicator: 3.3.2.a
-indicator_name: Multi-drug resistant tuberculosis morbidity indicator (per 100,000
-  population)
+indicator_name: meta.name-3-3-2-a
 indicator_sort_order: 03-03-02-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-3-a.md
+++ b/meta/3-3-3-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: cases
 data_non_statistical: false
-graph_title: Number of local cases in malaria per year
+graph_title: meta.name-3-3-3-a
 graph_type: line
 indicator: 3.3.3.a
-indicator_name: Number of local cases in malaria per year
+indicator_name: meta.name-3-3-3-a
 indicator_sort_order: 03-03-03-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-4-a.md
+++ b/meta/3-3-4-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: per 100,000 population
 data_non_statistical: false
-graph_title: 0-18 years old  patients with acute hepatitis B  ( per 100,000 population)
+graph_title: meta.name-3-3-4-a
 graph_type: line
 indicator: 3.3.4.a
-indicator_name: 0-18 years old  patients with acute hepatitis B  ( per 100,000 population)
+indicator_name: meta.name-3-3-4-a
 indicator_sort_order: 03-03-04-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-4-b.md
+++ b/meta/3-3-4-b.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Coverage of 3 doses of vaccine with hepatitis B alone or combined ingredient
-  with 95 and more ingredients
+graph_title: meta.name-3-3-4-b
 graph_type: line
 indicator: 3.3.4.b
-indicator_name: Coverage of 3 doses of vaccine with hepatitis B alone or combined
-  ingredient with 95 and more ingredients
+indicator_name: meta.name-3-3-4-b
 indicator_sort_order: 03-03-04-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-5-a.md
+++ b/meta/3-3-5-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Number of patients with leishmaniasis
+graph_title: meta.name-3-3-5-a
 graph_type: line
 indicator: 3.3.5.a
-indicator_name: Number of patients with leishmaniasis
+indicator_name: meta.name-3-3-5-a
 indicator_sort_order: 03-03-05-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-3-5-b.md
+++ b/meta/3-3-5-b.md
@@ -1,10 +1,10 @@
 ---
 computation_units: cases
 data_non_statistical: false
-graph_title: Case of death from leishmaniosis
+graph_title: meta.name-3-3-5-b
 graph_type: line
 indicator: 3.3.5.b
-indicator_name: Case of death from leishmaniosis
+indicator_name: meta.name-3-3-5-b
 indicator_sort_order: 03-03-05-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-5-1-a.md
+++ b/meta/3-5-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: per 100,000 population
 data_non_statistical: false
-graph_title: The number of patients suffering from drug addiction
+graph_title: meta.name-3-5-1-a
 graph_type: line
 indicator: 3.5.1.a
-indicator_name: The number of patients suffering from drug addiction
+indicator_name: meta.name-3-5-1-a
 indicator_sort_order: 03-05-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-7-2-a.md
+++ b/meta/3-7-2-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: per 1,000 women
 data_non_statistical: false
-graph_title: Adolescent birth rate (aged 15-17 years) per 1,000 women in that age
-  group
+graph_title: meta.name-3-7-2-a
 graph_type: line
 indicator: 3.7.2.a
-indicator_name: Adolescent birth rate (aged 15-17 years) per 1,000 women in that age
-  group
+indicator_name: meta.name-3-7-2-a
 indicator_sort_order: 03-07-02-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-8-1-a.md
+++ b/meta/3-8-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Providing antenatal care and care by qualified specialis
+graph_title: meta.name-3-8-1-a
 graph_type: line
 indicator: 3.8.1.a
-indicator_name: Providing antenatal care and care by qualified specialis
+indicator_name: meta.name-3-8-1-a
 indicator_sort_order: 03-08-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-8-1-b.md
+++ b/meta/3-8-1-b.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: At least one ultrasound examination during pregnancy
+graph_title: meta.name-3-8-1-b
 graph_type: line
 indicator: 3.8.1.b
-indicator_name: At least one ultrasound examination during pregnancy
+indicator_name: meta.name-3-8-1-b
 indicator_sort_order: 03-08-01-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-8-1-c.md
+++ b/meta/3-8-1-c.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: During the first two days after birth, the mother's postnatal check
+graph_title: meta.name-3-8-1-c
 graph_type: line
 indicator: 3.8.1.c
-indicator_name: During the first two days after birth, the mother's postnatal check
+indicator_name: meta.name-3-8-1-c
 indicator_sort_order: 03-08-01-0c
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-8-1-d.md
+++ b/meta/3-8-1-d.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: During the first two days after birth, the newborn testing
+graph_title: meta.name-3-8-1-d
 graph_type: line
 indicator: 3.8.1.d
-indicator_name: During the first two days after birth, the newborn testing
+indicator_name: meta.name-3-8-1-d
 indicator_sort_order: 03-08-01-0d
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-9-1-a.md
+++ b/meta/3-9-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: per 100,000 population
 data_non_statistical: false
-graph_title: Number of deaths caused by registered social-domestic toxication cases
+graph_title: meta.name-3-9-1-a
 graph_type: line
 indicator: 3.9.1.a
-indicator_name: Number of deaths caused by registered social-domestic toxication cases
+indicator_name: meta.name-3-9-1-a
 indicator_sort_order: 03-09-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-b-1-a.md
+++ b/meta/3-b-1-a.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Indicator of coverage  in vaccines among targeted quantities, 1 year
-  of age
+graph_title: meta.name-3-b-1-a
 graph_type: line
 indicator: 3.b.1.a
-indicator_name: Indicator of coverage  in vaccines among targeted quantities, 1 year
-  of age
+indicator_name: meta.name-3-b-1-a
 indicator_sort_order: 03-0b-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-b-1-b.md
+++ b/meta/3-b-1-b.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Indicator of coverage  in vaccines among targeted quantities, 2 years
-  of age
+graph_title: meta.name-3-b-1-b
 graph_type: line
 indicator: 3.b.1.b
-indicator_name: Indicator of coverage  in vaccines among targeted quantities, 2 years
-  of age
+indicator_name: meta.name-3-b-1-b
 indicator_sort_order: 03-0b-01-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-b-1-c.md
+++ b/meta/3-b-1-c.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Indicator of coverage  in vaccines among targeted quantities, 7 years
-  of age
+graph_title: meta.name-3-b-1-c
 graph_type: line
 indicator: 3.b.1.c
-indicator_name: Indicator of coverage  in vaccines among targeted quantities, 7 years
-  of age
+indicator_name: meta.name-3-b-1-c
 indicator_sort_order: 03-0b-01-0c
 national_geographical_coverage: Armenia
 published: true

--- a/meta/3-c-1-a.md
+++ b/meta/3-c-1-a.md
@@ -1,11 +1,10 @@
 ---
 computation_units: per 1,000 population
 data_non_statistical: false
-graph_title: Number of physicians conducting professional activities per 10,000 population
+graph_title: meta.name-3-c-1-a
 graph_type: line
 indicator: 3.c.1.a
-indicator_name: Number of physicians conducting professional activities per 10,000
-  population
+indicator_name: meta.name-3-c-1-a
 indicator_sort_order: 03-0c-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-1-1b.md
+++ b/meta/4-1-1b.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: "Proportion of children at the end of primary achieving at least a minimum\
-  \ proficiency level in  (i) reading and (ii)\_mathematics"
+graph_title: meta.name-4-1-1b
 graph_type: line
 indicator: 4.1.1b
-indicator_name: "Proportion of children at the end of primary achieving at least a\
-  \ minimum proficiency level in  (i) reading and (ii)\_mathematics"
+indicator_name: meta.name-4-1-1b
 indicator_sort_order: 04-01-1b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-1-1c.md
+++ b/meta/4-1-1c.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: "Proportion of children at\_the end of lower secondary achieving at least\
-  \ a minimum proficiency level in (i) reading and (ii)\_mathematics"
+graph_title: meta.name-4-1-1c
 graph_type: line
 indicator: 4.1.1c
-indicator_name: "Proportion of children at\_the end of lower secondary achieving at\
-  \ least a minimum proficiency level in (i) reading and (ii)\_mathematics"
+indicator_name: meta.name-4-1-1c
 indicator_sort_order: 04-01-1c
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-2-2-a.md
+++ b/meta/4-2-2-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Gross enrolment  of children 3 -5 years of age in pre-primary education
+graph_title: meta.name-4-2-2-a
 graph_type: line
 indicator: 4.2.2.a
-indicator_name: Gross enrolment  of children 3 -5 years of age in pre-primary education
+indicator_name: meta.name-4-2-2-a
 indicator_sort_order: 04-02-02-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-3-1-a.md
+++ b/meta/4-3-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Gross Enrollment Ration in general educatioin
+graph_title: meta.name-4-3-1-a
 graph_type: line
 indicator: 4.3.1.a
-indicator_name: Gross Enrollment Ration in general educatioin
+indicator_name: meta.name-4-3-1-a
 indicator_sort_order: 04-03-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-4-1-a.md
+++ b/meta/4-4-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: persons
 data_non_statistical: false
-graph_title: Number of pupils per computer in general education schools
+graph_title: meta.name-4-4-1-a
 graph_type: line
 indicator: 4.4.1.a
-indicator_name: Number of pupils per computer in general education schools
+indicator_name: meta.name-4-4-1-a
 indicator_sort_order: 04-04-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-5-1-a.md
+++ b/meta/4-5-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Gender parity index
+graph_title: meta.name-4-5-1-a
 graph_type: line
 indicator: 4.5.1.a
-indicator_name: Gender parity index
+indicator_name: meta.name-4-5-1-a
 indicator_sort_order: 04-05-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-6-1-a.md
+++ b/meta/4-6-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Literacy rate among population aged from 10-24  years old
+graph_title: meta.name-4-6-1-a
 graph_type: line
 indicator: 4.6.1.a
-indicator_name: Literacy rate among population aged from 10-24  years old
+indicator_name: meta.name-4-6-1-a
 indicator_sort_order: 04-06-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/4-c-1-a.md
+++ b/meta/4-c-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of trained teachers
+graph_title: meta.name-4-c-1-a
 graph_type: line
 indicator: 4.c.1.a
-indicator_name: Proportion of trained teachers
+indicator_name: meta.name-4-c-1-a
 indicator_sort_order: 04-0c-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/5-6-1-a.md
+++ b/meta/5-6-1-a.md
@@ -1,14 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Women currently married or in union that are using any type of contraception,
-  only Condition 3 "She can make a decision about healthcare either by herself or
-  jointly" fulfilled
+graph_title: meta.name-5-6-1-a
 graph_type: line
 indicator: 5.6.1.a
-indicator_name: Women currently married or in union that are using any type of contraception,
-  only Condition 3 "She can make a decision about healthcare either by herself or
-  jointly" fulfilled
+indicator_name: meta.name-5-6-1-a
 indicator_sort_order: 05-06-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/5-a-1-a-a.md
+++ b/meta/5-a-1-a-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of households with ownership over agricultural land
+graph_title: meta.name-5-a-1-a-a
 graph_type: line
 indicator: 5.a.1.a.a
-indicator_name: Proportion of households with ownership over agricultural land
+indicator_name: meta.name-5-a-1-a-a
 indicator_sort_order: 05-0a-01-0a-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/5-a-1-b-a-1.md
+++ b/meta/5-a-1-b-a-1.md
@@ -1,14 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of women age 15-49 with ownership (alone, jointly with someone
-  else or both alone and jointly with someone else) over agricultural or non-agricultural
-  land, who have a title deed and their name is listed on the title deed
+graph_title: meta.name-5-a-1-b-a-1
 graph_type: line
 indicator: 5.a.1.b.a.1
-indicator_name: Proportion of women age 15-49 with ownership (alone, jointly with
-  someone else or both alone and jointly with someone else) over agricultural or non-agricultural
-  land, who have a title deed and their name is listed on the title deed
+indicator_name: meta.name-5-a-1-b-a-1
 indicator_sort_order: 05-0a-01-0b-0a-01
 national_geographical_coverage: Armenia
 published: true

--- a/meta/5-a-1-b-a-2.md
+++ b/meta/5-a-1-b-a-2.md
@@ -1,14 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of men age 15-49 with ownership (alone, jointly with someone
-  else or both alone and jointly with someone else) over agricultural or non-agricultural
-  land, who have a title deed and their name is listed on the title deed
+graph_title: meta.name-5-a-1-b-a-2
 graph_type: line
 indicator: 5.a.1.b.a.2
-indicator_name: Proportion of men age 15-49 with ownership (alone, jointly with someone
-  else or both alone and jointly with someone else) over agricultural or non-agricultural
-  land, who have a title deed and their name is listed on the title deed
+indicator_name: meta.name-5-a-1-b-a-2
 indicator_sort_order: 05-0a-01-0b-0a-02
 national_geographical_coverage: Armenia
 published: true

--- a/meta/5-b-1-a.md
+++ b/meta/5-b-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of households who own a mobile telephone
+graph_title: meta.name-5-b-1-a
 graph_type: line
 indicator: 5.b.1.a
-indicator_name: Proportion of households who own a mobile telephone
+indicator_name: meta.name-5-b-1-a
 indicator_sort_order: 05-0b-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/6-1-1-a.md
+++ b/meta/6-1-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of  households with centralized water supply
+graph_title: meta.name-6-1-1-a
 graph_type: line
 indicator: 6.1.1.a
-indicator_name: Proportion of  households with centralized water supply
+indicator_name: meta.name-6-1-1-a
 indicator_sort_order: 06-01-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/6-2-1-a.md
+++ b/meta/6-2-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of population using safely managed sanitation facility
+graph_title: meta.name-6-2-1-a
 graph_type: line
 indicator: 6.2.1.a
-indicator_name: Proportion of population using safely managed sanitation facility
+indicator_name: meta.name-6-2-1-a
 indicator_sort_order: 06-02-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/6-2-1-b.md
+++ b/meta/6-2-1-b.md
@@ -1,11 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of population using hand-washing facility with soap and water
+graph_title: meta.name-6-2-1-b
 graph_type: line
 indicator: 6.2.1.b
-indicator_name: Proportion of population using hand-washing facility with soap and
-  water
+indicator_name: meta.name-6-2-1-b
 indicator_sort_order: 06-02-01-0b
 national_geographical_coverage: Armenia
 published: true

--- a/meta/6-2-1-c.md
+++ b/meta/6-2-1-c.md
@@ -1,12 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of population using sanitary-hygienic services defined by
-  sanitation norms
+graph_title: meta.name-6-2-1-c
 graph_type: line
 indicator: 6.2.1.c
-indicator_name: Proportion of population using sanitary-hygienic services defined
-  by sanitation norms
+indicator_name: meta.name-6-2-1-c
 indicator_sort_order: 06-02-01-0c
 national_geographical_coverage: Armenia
 published: true

--- a/meta/6-3-1-a.md
+++ b/meta/6-3-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of insufficiently treated wastewater
+graph_title: meta.name-6-3-1-a
 graph_type: line
 indicator: 6.3.1.a
-indicator_name: Proportion of insufficiently treated wastewater
+indicator_name: meta.name-6-3-1-a
 indicator_sort_order: 06-03-01-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/7-1-2-a.md
+++ b/meta/7-1-2-a.md
@@ -1,11 +1,10 @@
 ---
 computation_units: '%'
 data_non_statistical: false
-graph_title: Proportion of households with primary reliance on clean fuels and technology
+graph_title: meta.name-7-1-2-a
 graph_type: line
 indicator: 7.1.2.a
-indicator_name: Proportion of households with primary reliance on clean fuels and
-  technology
+indicator_name: meta.name-7-1-2-a
 indicator_sort_order: 07-01-02-0a
 national_geographical_coverage: Armenia
 published: true

--- a/meta/8-5-1-a.md
+++ b/meta/8-5-1-a.md
@@ -1,10 +1,10 @@
 ---
 computation_units: dram
 data_non_statistical: false
-graph_title: Average Monthly Nominal Wages / Salaries
+graph_title: meta.name-8-5-1-a
 graph_type: line
 indicator: 8.5.1.a
-indicator_name: Average Monthly Nominal Wages / Salaries
+indicator_name: meta.name-8-5-1-a
 indicator_sort_order: 08-05-01-0a
 national_geographical_coverage: Armenia
 published: true


### PR DESCRIPTION
For the "indicator_name" and "graph_title", point to "translation keys".

This fixes the problem where English names are appearing on non-English pages. For example see the indicator names [here](https://armstat.github.io/sdg-site-armenia/am/1-3-1-a/).

After this change, those names should be translated, according to the translations in `/data/translations/[language]/meta.yml`.