### PR TITLE
Translate global metadata on global indicators

### DIFF
--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-01-01a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: Proportion of population below the international poverty line, by sex,
-  age, employment status and geographical location (urban/rural)
+graph_title: global_indicators.1-1-1.title
 graph_type: line
 indicator: 1.1.1
-indicator_name: Proportion of population below the international poverty line, by
-  sex, age, employment status and geographical location (urban/rural)
+indicator_name: global_indicators.1-1-1.title
 indicator_sort_order: 01-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +16,7 @@ reporting_status: complete
 sdg_goal: '1'
 source_active_1: true
 source_organisation_1: Armstat, ILCS
-target: By 2030, eradicate extreme poverty for all people everywhere, currently measured
-  as people living on less than $1.25 a day
+target: global_targets.1-1.title
 target_id: '1.1'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -4,16 +4,14 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 98.2
   KB)
-graph_title: Proportion of population living below the national poverty line, by sex
-  and age
+graph_title: global_indicators.1-2-1.title
 graph_type: line
 indicator: 1.2.1
-indicator_definition: "Monitoring national poverty is important for country-specific\
-  \ development agendas. National poverty lines are used to make more accurate estimates\
-  \ of poverty consistent with the country\u2019s specific economic and social circumstances,\
-  \ and are not intended for international comparisons of poverty rates."
-indicator_name: Proportion of population living below the national poverty line, by
-  sex and age
+indicator_definition: Monitoring national poverty is important for country-specific
+  development agendas. National poverty lines are used to make more accurate estimates
+  of poverty consistent with the country’s specific economic and social circumstances,
+  and are not intended for international comparisons of poverty rates.
+indicator_name: global_indicators.1-2-1.title
 indicator_sort_order: 01-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -23,8 +21,7 @@ reporting_status: complete
 sdg_goal: '1'
 source_active_1: true
 source_organisation_1: Armstat, ILCS
-target: By 2030, reduce at least by half the proportion of men, women and children
-  of all ages living in poverty in all its dimensions according to national definitions.
+target: global_targets.1-2.title
 target_id: '1.2'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/1-2-2.md
+++ b/meta/1-2-2.md
@@ -4,16 +4,14 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 894
   KB)
-graph_title: Proportion of men, women and children of all ages living in poverty in
-  all its dimensions according to national definitions
+graph_title: global_indicators.1-2-2.title
 graph_type: line
 indicator: 1.2.2
-indicator_definition: "Monitoring national poverty is important for country-specific\
-  \ development agendas. National poverty lines are used to make more accurate estimates\
-  \ of poverty consistent with the country\u2019s specific economic and social circumstances,\
-  \ and are not intended for international comparisons of poverty rates."
-indicator_name: Proportion of men, women and children of all ages living in poverty
-  in all its dimensions according to national definitions
+indicator_definition: Monitoring national poverty is important for country-specific
+  development agendas. National poverty lines are used to make more accurate estimates
+  of poverty consistent with the country’s specific economic and social circumstances,
+  and are not intended for international comparisons of poverty rates.
+indicator_name: global_indicators.1-2-2.title
 indicator_sort_order: 01-02-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -23,8 +21,7 @@ reporting_status: complete
 sdg_goal: '1'
 source_active_1: true
 source_organisation_1: Armstat, ILCS, WB
-target: By 2030, reduce at least by half the proportion of men, women and children
-  of all ages living in poverty in all its dimensions according to national definitions
+target: global_targets.1-2.title
 target_id: '1.2'
 un_custodian_agency: United Nations Children's Fund (UNICEFF) World Bank (WB) United
   Nations Development Programme (UNDP)

--- a/meta/1-3-1.md
+++ b/meta/1-3-1.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-03-01a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
+graph_title: global_indicators.1-3-1.title
 graph_type: line
 indicator: 1.3.1
-indicator_name: Proportion of population covered by social protection floors/systems,
-  by sex, distinguishing children, unemployed persons, older persons, persons with
-  disabilities, pregnant women, newborns, work-injury victims and the poor and the
-  vulnerable
+indicator_name: global_indicators.1-3-1.title
 indicator_sort_order: 01-03-01
 layout: indicator
 permalink: /1-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Implement nationally appropriate social protection systems and measures for
-  all, including floors, and by 2030 achieve substantial coverage of the poor and
-  the vulnerable
+target: global_targets.1-3.title
 target_id: '1.3'
-graph_title: Proportion of population covered by social protection floors/systems, by sex,
-  distinguishing children, unemployed persons, older persons, persons with disabilities,
-  pregnant women, newborns, work-injury victims and the poor and the vulnerable
 un_custodian_agency: ILO
 un_designated_tier: '2'
 ---

--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
+graph_title: global_indicators.1-4-1.title
 graph_type: line
 indicator: 1.4.1
-indicator_name: Proportion of population living in households with access to basic
-  services
+indicator_name: global_indicators.1-4-1.title
 indicator_sort_order: 01-04-01
 layout: indicator
 permalink: /1-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, ensure that all men and women, in particular the poor and the vulnerable,
-  have equal rights to economic resources, as well as access to basic services, ownership
-  and control over land and other forms of property, inheritance, natural resources,
-  appropriate new technology and financial services, including microfinance.
+target: global_targets.1-4.title
 target_id: '1.4'
-graph_title: Proportion of population living in households with access to basic services
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'
 ---

--- a/meta/1-4-2.md
+++ b/meta/1-4-2.md
@@ -3,25 +3,18 @@ data_non_statistical: false
 goal_meta_link: NA
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.1-4-2.title
 graph_type: line
 indicator: 1.4.2
-indicator_name: Proportion of total adult population with secure tenure rights to
-  land, with legally recognized documentation and who perceive their rights to land
-  as secure, by sex and by type of tenure
+indicator_name: global_indicators.1-4-2.title
 indicator_sort_order: 01-04-02
 layout: indicator
 permalink: /1-4-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, ensure that all men and women, in particular the poor and the vulnerable,
-  have equal rights to economic resources, as well as access to basic services, ownership
-  and control over land and other forms of property, inheritance, natural resources,
-  appropriate new technology and financial services, including microfinance.
+target: global_targets.1-4.title
 target_id: '1.4'
-graph_title: Proportion of total adult population with secure tenure rights to land, with
-  legally recognized documentation and who perceive their rights to land as secure,
-  by sex and by type of tenure
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '2'
 ---

--- a/meta/1-5-1.md
+++ b/meta/1-5-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
   KB)
+graph_title: global_indicators.1-5-1.title
 graph_type: line
 indicator: 1.5.1
-indicator_name: Number of deaths, missing persons and directly affected persons attributed
-  to disasters per 100,000 population (repeat of 1 and 13.1.1)
+indicator_name: global_indicators.1-5-1.title
 indicator_sort_order: 01-05-01
 layout: indicator
 permalink: /1-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target: global_targets.1-5.title
 target_id: '1.5'
-graph_title: Number of deaths, missing persons and directly affected persons attributed
-  to disasters per 100,000 population (repeat of 1 and 13.1.1)
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'
 ---

--- a/meta/1-5-2.md
+++ b/meta/1-5-2.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
+graph_title: global_indicators.1-5-2.title
 graph_type: line
 indicator: 1.5.2
-indicator_name: Direct economic loss attributed to disasters in relation to global
-  gross domestic product (GDP)
+indicator_name: global_indicators.1-5-2.title
 indicator_sort_order: 01-05-02
 layout: indicator
 permalink: /1-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target: global_targets.1-5.title
 target_id: '1.5'
-graph_title: Direct economic loss attributed to disasters in relation to global gross domestic
-  product (GDP)
 un_custodian_agency: UNISDR
 un_designated_tier: '2'
 ---

--- a/meta/1-5-3.md
+++ b/meta/1-5-3.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
+graph_title: global_indicators.1-5-3.title
 graph_type: line
 indicator: 1.5.3
-indicator_name: Number of countries that adopt and implement national disaster risk
-  reduction strategies in line with the Sendai Framework for Disaster Risk Reduction
-  2015-2030
+indicator_name: global_indicators.1-5-3.title
 indicator_sort_order: 01-05-03
 layout: indicator
 permalink: /1-5-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target: global_targets.1-5.title
 target_id: '1.5'
-graph_title: Number of countries that adopt and implement national disaster risk reduction
-  strategies in line with the Sendai Framework for Disaster Risk Reduction 2015-2030
 un_custodian_agency: UNISDR
 un_designated_tier: '1'
 ---

--- a/meta/1-5-4.md
+++ b/meta/1-5-4.md
@@ -1,22 +1,18 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
+graph_title: global_indicators.1-5-4.title
 graph_type: line
 indicator: 1.5.4
-indicator_name: Proportion of local governments that adopt and implement local disaster
-  risk reduction strategies in line with national disaster risk reduction strategies
+indicator_name: global_indicators.1-5-4.title
 indicator_sort_order: 01-05-04
 layout: indicator
 permalink: /1-5-4/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: By 2030, build the resilience of the poor and those in vulnerable situations
-  and reduce their exposure and vulnerability to climate-related extreme events and
-  other economic, social and environmental shocks and disasters
+target: global_targets.1-5.title
 target_id: '1.5'
-graph_title: Proportion of local governments that adopt and implement local disaster risk
-  reduction strategies in line with national disaster risk reduction strategies
 un_custodian_agency: UNISDR
 un_designated_tier: '2'
 ---

--- a/meta/1-a-1.md
+++ b/meta/1-a-1.md
@@ -2,22 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
+graph_title: global_indicators.1-a-1.title
 graph_type: line
 indicator: 1.a.1
-indicator_name: Proportion of domestically generated resources allocated by the government
-  directly to poverty reduction programmes
+indicator_name: global_indicators.1-a-1.title
 indicator_sort_order: 01-aa-01
 layout: indicator
 permalink: /1-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Ensure significant mobilization of resources from a variety of sources, including
-  through enhanced development cooperation, in order to provide adequate and predictable
-  means for developing countries, in particular least developed countries, to implement
-  programmes and policies to end poverty in all its dimensions
+target: global_targets.1-a.title
 target_id: 1.a
-graph_title: Proportion of domestically generated resources allocated by the government
-  directly to poverty reduction programmes
 un_designated_tier: '3'
 ---

--- a/meta/1-a-2.md
+++ b/meta/1-a-2.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: TIER III - NO WORK PLAN
-graph_title: Proportion of total government spending on essential services (education,
-  health and social protection)
+graph_title: global_indicators.1-a-2.title
 graph_type: line
 indicator: 1.a.2
-indicator_name: Proportion of total government spending on essential services (education,
-  health and social protection)
+indicator_name: global_indicators.1-a-2.title
 indicator_sort_order: 01-aa-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,10 +16,7 @@ reporting_status: complete
 sdg_goal: '1'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Finance of RA
-target: Ensure significant mobilization of resources from a variety of sources, including
-  through enhanced development cooperation, in order to provide adequate and predictable
-  means for developing countries, in particular least developed countries, to implement
-  programmes and policies to end poverty in all its dimensions
+target: global_targets.1-a.title
 target_id: 1.a
 un_custodian_agency: Discussions are occurring between the following organisations
   International Labour Organization (ILO) United Nations Educational Scientific and

--- a/meta/1-a-3.md
+++ b/meta/1-a-3.md
@@ -1,22 +1,17 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
+graph_title: global_indicators.1-a-3.title
 graph_type: line
 indicator: 1.a.3
-indicator_name: Sum of total grants and non-debt-creating inflows directly allocated
-  to poverty reduction programmes as a proportion of GDP
+indicator_name: global_indicators.1-a-3.title
 indicator_sort_order: 01-aa-03
 layout: indicator
 permalink: /1-a-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Ensure significant mobilization of resources from a variety of sources, including
-  through enhanced development cooperation, in order to provide adequate and predictable
-  means for developing countries, in particular least developed countries, to implement
-  programmes and policies to end poverty in all its dimensions
+target: global_targets.1-a.title
 target_id: 1.a
-graph_title: Sum of total grants and non-debt-creating inflows directly allocated to poverty
-  reduction programmes as a proportion of GDP
 un_designated_tier: '3'
 ---

--- a/meta/1-b-1.md
+++ b/meta/1-b-1.md
@@ -2,21 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
+graph_title: global_indicators.1-b-1.title
 graph_type: line
 indicator: 1.b.1
-indicator_name: Proportion of government recurrent and capital spending to sectors
-  that disproportionately benefit women, the poor and vulnerable groups
+indicator_name: global_indicators.1-b-1.title
 indicator_sort_order: 01-bb-01
 layout: indicator
 permalink: /1-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: Create sound policy frameworks at the national, regional and international
-  levels, based on pro-poor and gender-sensitive development strategies, to support
-  accelerated investment in poverty eradication actions
+target: global_targets.1-b.title
 target_id: 1.b
-graph_title: Proportion of government recurrent and capital spending to sectors that disproportionately
-  benefit women, the poor and vulnerable groups
 un_designated_tier: '3'
 ---

--- a/meta/10-1-1.md
+++ b/meta/10-1-1.md
@@ -4,12 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 221
   KB)
-graph_title: Growth rates of household expenditure or income per capita among the
-  bottom 40 per cent of the population and the total population
+graph_title: global_indicators.10-1-1.title
 graph_type: line
 indicator: 10.1.1
-indicator_name: Growth rates of household expenditure or income per capita among the
-  bottom 40 per cent of the population and the total population
+indicator_name: global_indicators.10-1-1.title
 indicator_sort_order: 10-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,8 +17,7 @@ reporting_status: complete
 sdg_goal: '10'
 source_active_1: true
 source_organisation_1: Armstat, ILCS, WB
-target: 10.1 By 2030, progressively achieve and sustain income growth of the bottom
-  40 per cent of the population at a rate higher than the national average
+target: global_targets.10-1.title
 target_id: '10.1'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: 2

--- a/meta/10-2-1.md
+++ b/meta/10-2-1.md
@@ -3,6 +3,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.10-2-1.title
 graph_type: line
 indicator: 10.2.1
 indicator_definition: This indicator is a measure of relative income poverty at the
@@ -12,20 +13,15 @@ indicator_definition: This indicator is a measure of relative income poverty at 
   unemployment, poor housing, inadequate health care and barriers in accessing education
   and economic, social, political and cultural activities, which can result from social
   stigmatisation.
-indicator_name: Proportion of people living below 50 per cent of median income, by
-  sex, age and persons with disabilities
+indicator_name: global_indicators.10-2-1.title
 indicator_sort_order: 10-02-01
 layout: indicator
 permalink: /10-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: By 2030, empower and promote the social, economic and political inclusion
-  of all, irrespective of age, sex, disability, race, ethnicity, origin, religion
-  or economic or other status
+target: global_targets.10-2.title
 target_id: '10.2'
-graph_title: Proportion of people living below 50 per cent of median income, by sex, age
-  and persons with disabilities
 un_custodian_agency: United Nations Children's Fund (UNICEF) World Bank (WB)
 un_designated_tier: '3'
 ---

--- a/meta/10-3-1.md
+++ b/meta/10-3-1.md
@@ -3,24 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.10-3-1.title
 graph_type: line
 indicator: 10.3.1
-indicator_name: Proportion of population reporting having personally felt discriminated
-  against or harassed in the previous 12 months on the basis of a ground of discrimination
-  prohibited under international human rights law
+indicator_name: global_indicators.10-3-1.title
 indicator_sort_order: 10-03-01
 layout: indicator
 permalink: /10-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Ensure equal opportunity and reduce inequalities of outcome, including by
-  eliminating discriminatory laws, policies and practices and promoting appropriate
-  legislation, policies and action in this regard
+target: global_targets.10-3.title
 target_id: '10.3'
-graph_title: Proportion of population reporting having personally felt discriminated against
-  or harassed in the previous 12 months on the basis of a ground of discrimination
-  prohibited under international human rights law
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)
 un_designated_tier: '3'

--- a/meta/10-4-1.md
+++ b/meta/10-4-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 190
   KB)
-graph_title: Labour share of GDP, comprising wages and social protection transfers
+graph_title: global_indicators.10-4-1.title
 graph_type: line
 indicator: 10.4.1
-indicator_name: Labour share of GDP, comprising wages and social protection transfers
+indicator_name: global_indicators.10-4-1.title
 indicator_sort_order: 10-04-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,8 +17,7 @@ reporting_status: complete
 sdg_goal: '10'
 source_active_1: true
 source_organisation_1: Armstat
-target: Adopt policies, especially fiscal, wage and social protection policies, and
-  progressively achieve greater equality
+target: global_targets.10-4.title
 target_id: '10.4'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '2'

--- a/meta/10-5-1.md
+++ b/meta/10-5-1.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
+graph_title: global_indicators.10-5-1.title
 graph_type: line
 indicator: 10.5.1
-indicator_name: Financial Soundness Indicators
+indicator_name: global_indicators.10-5-1.title
 indicator_sort_order: 10-05-01
 layout: indicator
 permalink: /10-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Improve the regulation and monitoring of global financial markets and institutions
-  and strengthen the implementation of such regulations
+target: global_targets.10-5.title
 target_id: '10.5'
-graph_title: Financial Soundness Indicators
 un_custodian_agency: IMF
 un_designated_tier: '3'
 ---

--- a/meta/10-6-1.md
+++ b/meta/10-6-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 201
   KB)
+graph_title: global_indicators.10-6-1.title
 graph_type: line
 indicator: 10.6.1
-indicator_name: Proportion of members and voting rights of developing countries in
-  international organizations
+indicator_name: global_indicators.10-6-1.title
 indicator_sort_order: 10-06-01
 layout: indicator
 permalink: /10-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Ensure enhanced representation and voice for developing countries in decision-making
-  in global international economic and financial institutions in order to deliver
-  more effective, credible, accountable and legitimate institutions
+target: global_targets.10-6.title
 target_id: '10.6'
-graph_title: Proportion of members and voting rights of developing countries in international
-  organizations
 un_custodian_agency: United Nations Department of Economic and Social Affairs (DESA)
   / Financing for Development Office (FFDO)
 un_designated_tier: '1'

--- a/meta/10-7-1.md
+++ b/meta/10-7-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
+graph_title: global_indicators.10-7-1.title
 graph_type: line
 indicator: 10.7.1
-indicator_name: Recruitment cost borne by employee as a proportion of yearly income
-  earned in country of destination
+indicator_name: global_indicators.10-7-1.title
 indicator_sort_order: 10-07-01
 layout: indicator
 permalink: /10-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Facilitate orderly, safe, regular and responsible migration and mobility of
-  people, including through the implementation of planned and well-managed migration
-  policies
+target: global_targets.10-7.title
 target_id: '10.7'
-graph_title: Recruitment cost borne by employee as a proportion of yearly income earned
-  in country of destination
 un_custodian_agency: ILO,World Bank
 un_designated_tier: '3'
 ---

--- a/meta/10-7-2.md
+++ b/meta/10-7-2.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
+graph_title: global_indicators.10-7-2.title
 graph_type: line
 indicator: 10.7.2
-indicator_name: Number of countries that have implemented well-managed migration policies
+indicator_name: global_indicators.10-7-2.title
 indicator_sort_order: 10-07-02
 layout: indicator
 permalink: /10-7-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Facilitate orderly, safe, regular and responsible migration and mobility of
-  people, including through the implementation of planned and well-managed migration
-  policies
+target: global_targets.10-7.title
 target_id: '10.7'
-graph_title: Number of countries that have implemented well-managed migration policies
 un_custodian_agency: DESA Population Division,IOM
 un_designated_tier: '3'
 ---

--- a/meta/10-a-1.md
+++ b/meta/10-a-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
+graph_title: global_indicators.10-a-1.title
 graph_type: line
 indicator: 10.a.1
-indicator_name: Proportion of tariff lines applied to imports from least developed
-  countries and developing countries with zero-tariff
+indicator_name: global_indicators.10-a-1.title
 indicator_sort_order: 10-aa-01
 layout: indicator
 permalink: /10-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Implement the principle of special and differential treatment for developing
-  countries, in particular least developed countries, in accordance with World Trade
-  Organization agreements
+target: global_targets.10-a.title
 target_id: 10.a
-graph_title: Proportion of tariff lines applied to imports from least developed countries
-  and developing countries with zero-tariff
 un_custodian_agency: ITC,UNCTAD,WTO
 un_designated_tier: '1'
 ---

--- a/meta/10-b-1.md
+++ b/meta/10-b-1.md
@@ -3,28 +3,21 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-10-0B-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 202
   KB)
+graph_title: global_indicators.10-b-1.title
 graph_type: line
 indicator: 10.b.1
 indicator_definition: Total resource flows for development, by recipient and donor
   countries and type of flow comprises of Official Development Assistance (ODA), other
   official flows (OOF) and private flows.
-indicator_name: Total resource flows for development, by recipient and donor countries
-  and type of flow (e.g. official development assistance, foreign direct investment
-  and other flows)
+indicator_name: global_indicators.10-b-1.title
 indicator_sort_order: 10-bb-01
 layout: indicator
 permalink: /10-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: Encourage official development assistance and financial flows, including foreign
-  direct investment, to States where the need is greatest, in particular least developed
-  countries, African countries, small island developing States and landlocked developing
-  countries, in accordance with their national plans and programmes
+target: global_targets.10-b.title
 target_id: 10.b
-graph_title: Total resource flows for development, by recipient and donor countries and
-  type of flow (e.g. official development assistance, foreign direct investment and
-  other flows)
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1 (ODA) / 2 (FDI)
 ---

--- a/meta/10-c-1.md
+++ b/meta/10-c-1.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
+graph_title: global_indicators.10-c-1.title
 graph_type: line
 indicator: 10.c.1
-indicator_name: Remittance costs as a proportion of the amount remitted
+indicator_name: global_indicators.10-c-1.title
 indicator_sort_order: 10-cc-01
 layout: indicator
 permalink: /10-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: By 2030, reduce to less than 3 per cent the transaction costs of migrant remittances
-  and eliminate remittance corridors with costs higher than 5 per cent
+target: global_targets.10-c.title
 target_id: 10.c
-graph_title: Remittance costs as a proportion of the amount remitted
 un_custodian_agency: World Bank
 un_designated_tier: '2'
 ---

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -4,12 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 93.1
   KB)
-graph_title: Proportion of urban population living in slums, informal settlements
-  or inadequate housing
+graph_title: global_indicators.11-1-1.title
 graph_type: line
 indicator: 11.1.1
-indicator_name: Proportion of urban population living in slums, informal settlements
-  or inadequate housing
+indicator_name: global_indicators.11-1-1.title
 indicator_sort_order: 11-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,8 +17,7 @@ reporting_status: complete
 sdg_goal: '11'
 source_active_1: true
 source_organisation_1: Armstat, Population Census
-target: By 2030, ensure access for all to adequate, safe and affordable housing and
-  basic services and upgrade slums
+target: global_targets.11-1.title
 target_id: '11.1'
 un_custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
 un_designated_tier: '1'

--- a/meta/11-2-1.md
+++ b/meta/11-2-1.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
+graph_title: global_indicators.11-2-1.title
 graph_type: line
 indicator: 11.2.1
-indicator_name: Proportion of population that has convenient access to public transport,
-  by sex, age and persons with disabilities
+indicator_name: global_indicators.11-2-1.title
 indicator_sort_order: 11-02-01
 layout: indicator
 permalink: /11-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, provide access to safe, affordable, accessible and sustainable transport
-  systems for all, improving road safety, notably by expanding public transport, with
-  special attention to the needs of those in vulnerable situations, women, children,
-  persons with disabilities and older persons
+target: global_targets.11-2.title
 target_id: '11.2'
-graph_title: Proportion of population that has convenient access to public transport, by
-  sex, age and persons with disabilities
 un_custodian_agency: UN-Habitat
 un_designated_tier: '2'
 ---

--- a/meta/11-3-1.md
+++ b/meta/11-3-1.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
+graph_title: global_indicators.11-3-1.title
 graph_type: line
 indicator: 11.3.1
-indicator_name: Ratio of land consumption rate to population growth rate
+indicator_name: global_indicators.11-3-1.title
 indicator_sort_order: 11-03-01
 layout: indicator
 permalink: /11-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, enhance inclusive and sustainable urbanization and capacity for participatory,
-  integrated and sustainable human settlement planning and management in all countries
+target: global_targets.11-3.title
 target_id: '11.3'
-graph_title: Ratio of land consumption rate to population growth rate
 un_custodian_agency: UN-Habitat
 un_designated_tier: '2'
 ---

--- a/meta/11-3-2.md
+++ b/meta/11-3-2.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
+graph_title: global_indicators.11-3-2.title
 graph_type: line
 indicator: 11.3.2
-indicator_name: Proportion of cities with a direct participation structure of civil
-  society in urban planning and management that operate regularly and democratically
+indicator_name: global_indicators.11-3-2.title
 indicator_sort_order: 11-03-02
 layout: indicator
 permalink: /11-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, enhance inclusive and sustainable urbanization and capacity for participatory,
-  integrated and sustainable human settlement planning and management in all countries
+target: global_targets.11-3.title
 target_id: '11.3'
-graph_title: Proportion of cities with a direct participation structure of civil society
-  in urban planning and management that operate regularly and democratically
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'
 ---

--- a/meta/11-4-1.md
+++ b/meta/11-4-1.md
@@ -2,27 +2,18 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.11-4-1.title
 graph_type: line
 indicator: 11.4.1
-indicator_name: Total expenditure (public and private) per capita spent on the preservation,
-  protection and conservation of all cultural and natural heritage, by type of heritage
-  (cultural, natural, mixed and World Heritage Centre designation), level of government
-  (national, regional and local/municipal), type of expenditure (operating expenditure/investment)
-  and type of private funding (donations in kind, private non-profit sector and sponsorship)
+indicator_name: global_indicators.11-4-1.title
 indicator_sort_order: 11-04-01
 layout: indicator
 permalink: /11-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: "Strengthen efforts to protect and safeguard the world\u2019s cultural and\
-  \ natural heritage"
+target: global_targets.11-4.title
 target_id: '11.4'
-graph_title: Total expenditure (public and private) per capita spent on the preservation,
-  protection and conservation of all cultural and natural heritage, by type of heritage
-  (cultural, natural, mixed and World Heritage Centre designation), level of government
-  (national, regional and local/municipal), type of expenditure (operating expenditure/investment)
-  and type of private funding (donations in kind, private non-profit sector and sponsorship)
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)
 un_designated_tier: '3'

--- a/meta/11-5-1.md
+++ b/meta/11-5-1.md
@@ -3,23 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
   KB)
+graph_title: global_indicators.11-5-1.title
 graph_type: line
 indicator: 11.5.1
-indicator_name: Number of deaths, missing persons and directly affected persons attributed
-  to disasters per 100,000 population (repeat of and 13.1.1)
+indicator_name: global_indicators.11-5-1.title
 indicator_sort_order: 11-05-01
 layout: indicator
 permalink: /11-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, significantly reduce the number of deaths and the number of people
-  affected and substantially decrease the direct economic losses relative to global
-  gross domestic product caused by disasters, including water-related disasters, with
-  a focus on protecting the poor and people in vulnerable situations
+target: global_targets.11-5.title
 target_id: '11.5'
-graph_title: Number of deaths, missing persons and directly affected persons attributed
-  to disasters per 100,000 population (repeat of and 13.1.1)
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'
 ---

--- a/meta/11-5-2.md
+++ b/meta/11-5-2.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
+graph_title: global_indicators.11-5-2.title
 graph_type: line
 indicator: 11.5.2
-indicator_name: Direct economic loss in relation to global GDP, damage to critical
-  infrastructure and number of disruptions to basic services, attributed to disasters
+indicator_name: global_indicators.11-5-2.title
 indicator_sort_order: 11-05-02
 layout: indicator
 permalink: /11-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, significantly reduce the number of deaths and the number of people
-  affected and substantially decrease the direct economic losses relative to global
-  gross domestic product caused by disasters, including water-related disasters, with
-  a focus on protecting the poor and people in vulnerable situations
+target: global_targets.11-5.title
 target_id: '11.5'
-graph_title: Direct economic loss in relation to global GDP, damage to critical infrastructure
-  and number of disruptions to basic services, attributed to disasters
 un_custodian_agency: UNISDR
 un_designated_tier: '1'
 ---

--- a/meta/11-6-1.md
+++ b/meta/11-6-1.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: Proportion of urban solid waste regularly collected and with adequate
-  final discharge out of total urban solid waste generated, by cities
+graph_title: global_indicators.11-6-1.title
 graph_type: line
 indicator: 11.6.1
-indicator_name: Proportion of urban solid waste regularly collected and with adequate
-  final discharge out of total urban solid waste generated, by cities
+indicator_name: global_indicators.11-6-1.title
 indicator_sort_order: 11-06-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +16,7 @@ reporting_status: complete
 sdg_goal: '11'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Nature Protection of RA
-target: By 2030, reduce the adverse per capita environmental impact of cities, including
-  by paying special attention to air quality and municipal and other waste management
+target: global_targets.11-6.title
 target_id: '11.6'
 un_custodian_agency: UN-Habitat,UNSD
 un_designated_tier: '2'

--- a/meta/11-6-2.md
+++ b/meta/11-6-2.md
@@ -3,21 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
+graph_title: global_indicators.11-6-2.title
 graph_type: line
 indicator: 11.6.2
-indicator_name: Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10)
-  in cities (population weighted)
+indicator_name: global_indicators.11-6-2.title
 indicator_sort_order: 11-06-02
 layout: indicator
 permalink: /11-6-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, reduce the adverse per capita environmental impact of cities, including
-  by paying special attention to air quality and municipal and other waste management.
+target: global_targets.11-6.title
 target_id: '11.6'
-graph_title: Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10) in cities
-  (population weighted)
 un_custodian_agency: World Health Organization (WHO)
 un_designated_tier: '1'
 ---

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
+graph_title: global_indicators.11-7-1.title
 graph_type: line
 indicator: 11.7.1
-indicator_name: Average share of the built-up area of cities that is open space for
-  public use for all, by sex, age and persons with disabilities
+indicator_name: global_indicators.11-7-1.title
 indicator_sort_order: 11-07-01
 layout: indicator
 permalink: /11-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, provide universal access to safe, inclusive and accessible, green
-  and public spaces, in particular for women and children, older persons and persons
-  with disabilities
+target: global_targets.11-7.title
 target_id: '11.7'
-graph_title: Average share of the built-up area of cities that is open space for public
-  use for all, by sex, age and persons with disabilities
 un_custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
 un_designated_tier: '2'
 ---

--- a/meta/11-7-2.md
+++ b/meta/11-7-2.md
@@ -3,24 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.11-7-2.title
 graph_type: line
 indicator: 11.7.2
 indicator_definition: Proportion of persons victim of physical or sexual harassment,
   by sex, age, disability status and place of occurrence, in the previous 12 months
-indicator_name: Proportion of persons victim of physical or sexual harassment, by
-  sex, age, disability status and place of occurrence, in the previous 12 months
+indicator_name: global_indicators.11-7-2.title
 indicator_sort_order: 11-07-02
 layout: indicator
 permalink: /11-7-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2030, provide universal access to safe, inclusive and accessible, green
-  and public spaces, in particular for women and children, older persons and persons
-  with disabilities
+target: global_targets.11-7.title
 target_id: '11.7'
-graph_title: Proportion of persons victim of physical or sexual harassment, by sex, age,
-  disability status and place of occurrence, in the previous 12 months
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '3'
 ---

--- a/meta/11-a-1.md
+++ b/meta/11-a-1.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
+graph_title: global_indicators.11-a-1.title
 graph_type: line
 indicator: 11.a.1
-indicator_name: Proportion of population living in cities that implement urban and
-  regional development plans integrating population projections and resource needs,
-  by size of city
+indicator_name: global_indicators.11-a-1.title
 indicator_sort_order: 11-aa-01
 layout: indicator
 permalink: /11-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: Support positive economic, social and environmental links between urban, peri-urban
-  and rural areas by strengthening national and regional development planning
+target: global_targets.11-a.title
 target_id: 11.a
-graph_title: Proportion of population living in cities that implement urban and regional
-  development plans integrating population projections and resource needs, by size
-  of city
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'
 ---

--- a/meta/11-b-1.md
+++ b/meta/11-b-1.md
@@ -3,13 +3,10 @@ computation_units: yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: Number of countries that adopt and implement national disaster risk reduction
-  strategies in line with the Sendai Framework for Disaster Risk Reduction 2015-2029
+graph_title: global_indicators.11-b-1.title
 graph_type: line
 indicator: 11.b.1
-indicator_name: Number of countries that adopt and implement national disaster risk
-  reduction strategies in line with the Sendai Framework for Disaster Risk Reduction
-  2015-2029
+indicator_name: global_indicators.11-b-1.title
 indicator_sort_order: 11-bb-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,11 +16,7 @@ reporting_status: complete
 sdg_goal: '11'
 source_active_1: true
 source_organisation_1: Ministry of Emergency situations of RA
-target: By 2020, substantially increase the number of cities and human settlements
-  adopting and implementing integrated policies and plans towards inclusion, resource
-  efficiency, mitigation and adaptation to climate change, resilience to disasters,
-  and develop and implement, in line with the Sendai Framework for Disaster Risk Reduction
-  2015-2030, holistic disaster risk management at all levels
+target: global_targets.11-b.title
 target_id: 11.b
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/11-b-2.md
+++ b/meta/11-b-2.md
@@ -2,24 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
+graph_title: global_indicators.11-b-2.title
 graph_type: line
 indicator: 11.b.2
-indicator_name: Proportion of local governments that adopt and implement local disaster
-  risk reduction strategies in line with national disaster risk reduction strategies
+indicator_name: global_indicators.11-b-2.title
 indicator_sort_order: 11-bb-02
 layout: indicator
 permalink: /11-b-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: By 2020, substantially increase the number of cities and human settlements
-  adopting and implementing integrated policies and plans towards inclusion, resource
-  efficiency, mitigation and adaptation to climate change, resilience to disasters,
-  and develop and implement, in line with the Sendai Framework for Disaster Risk Reduction
-  2015-2030, holistic disaster risk management at all levels
+target: global_targets.11-b.title
 target_id: 11.b
-graph_title: Proportion of local governments that adopt and implement local disaster risk
-  reduction strategies in line with national disaster risk reduction strategies
 un_custodian_agency: UNISDR
 un_designated_tier: '3'
 ---

--- a/meta/11-c-1.md
+++ b/meta/11-c-1.md
@@ -3,27 +3,22 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/?Text=&Goal=11&Target= '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.11-c-1.title
 graph_type: line
 indicator: 11.c.1
 indicator_definition: Proportion of financial support to the least developed countries
   that is allocated to the construction and retrofitting of sustainable, resilient
   and resource-efficient buildings utilizing local materials.
-indicator_name: Proportion of financial support to the least developed countries that
-  is allocated to the construction and retrofitting of sustainable, resilient and
-  resource-efficient buildings utilizing local materials
+indicator_name: global_indicators.11-c-1.title
 indicator_sort_order: 11-cc-01
 layout: indicator
 permalink: /11-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: Support least developed countries, including through financial and technical
-  assistance, in building sustainable and resilient buildings utilizing local materials
+target: global_targets.11-c.title
 target_id: 11.c
-graph_title: Proportion of financial support to the least developed countries that is allocated
-  to the construction and retrofitting of sustainable, resilient and resource-efficient
-  buildings utilizing local materials
-un_custodian_agency: "\_Organisation for Economic Co-operation and Development (OECD)\
-  \ United Nations Environment (UNEP) World Bank (WB)"
+un_custodian_agency:  Organisation for Economic Co-operation and Development (OECD)
+  United Nations Environment (UNEP) World Bank (WB)
 un_designated_tier: '3'
 ---

--- a/meta/12-1-1.md
+++ b/meta/12-1-1.md
@@ -3,14 +3,10 @@ computation_units: yes=1, no=0
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: Number of countries with sustainable consumption and production (SCP)
-  national action plans or SCP mainstreamed as a priority or a target into national
-  policies
+graph_title: global_indicators.12-1-1.title
 graph_type: line
 indicator: 12.1.1
-indicator_name: Number of countries with sustainable consumption and production (SCP)
-  national action plans or SCP mainstreamed as a priority or a target into national
-  policies
+indicator_name: global_indicators.12-1-1.title
 indicator_sort_order: 12-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,9 +14,7 @@ permalink: /12-1-1/
 published: true
 reporting_status: complete
 sdg_goal: '12'
-target: Implement the 10-Year Framework of Programmes on Sustainable Consumption and
-  Production Patterns, all countries taking action, with developed countries taking
-  the lead, taking into account the development and capabilities of developing countries
+target: global_targets.12-1.title
 target_id: '12.1'
 un_custodian_agency: UNEP
 un_designated_tier: '2'

--- a/meta/12-2-1.md
+++ b/meta/12-2-1.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.12-2-1.title
 graph_type: line
 indicator: 12.2.1
-indicator_name: Material footprint, material footprint per capita, and material footprint
-  per GDP
+indicator_name: global_indicators.12-2-1.title
 indicator_sort_order: 12-02-01
 layout: indicator
 permalink: /12-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, achieve the sustainable management and efficient use of natural resources
+target: global_targets.12-2.title
 target_id: '12.2'
-graph_title: Material footprint, material footprint per capita, and material footprint per
-  GDP
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '3'
 ---

--- a/meta/12-2-2.md
+++ b/meta/12-2-2.md
@@ -3,12 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 783
   KB)
-graph_title: Domestic material consumption, domestic material consumption per capita,
-  and domestic material consumption per GDP
+graph_title: global_indicators.12-2-2.title
 graph_type: line
 indicator: 12.2.2
-indicator_name: Domestic material consumption, domestic material consumption per capita,
-  and domestic material consumption per GDP
+indicator_name: global_indicators.12-2-2.title
 indicator_sort_order: 12-02-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,7 +16,7 @@ reporting_status: complete
 sdg_goal: '12'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, achieve the sustainable management and efficient use of natural resources
+target: global_targets.12-2.title
 target_id: '12.2'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '2'

--- a/meta/12-3-1.md
+++ b/meta/12-3-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-3-1.title
 graph_type: line
 indicator: 12.3.1
-indicator_name: Global food loss index
+indicator_name: global_indicators.12-3-1.title
 indicator_sort_order: 12-03-01
 layout: indicator
 permalink: /12-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, halve per capita global food waste at the retail and consumer levels
-  and reduce food losses along production and supply chains, including post-harvest
-  losses
+target: global_targets.12-3.title
 target_id: '12.3'
-graph_title: Global food loss index
 un_custodian_agency: FAO, UNEP
 un_designated_tier: '3'
 ---

--- a/meta/12-4-1.md
+++ b/meta/12-4-1.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-12-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-4-1.title
 graph_type: line
 indicator: 12.4.1
-indicator_name: Number of parties to international multilateral environmental agreements
-  on hazardous waste, and other chemicals that meet their commitments and obligations
-  in transmitting information as required by each relevant agreement
+indicator_name: global_indicators.12-4-1.title
 indicator_sort_order: 12-04-01
 layout: indicator
 permalink: /12-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2020, achieve the environmentally sound management of chemicals and all
-  wastes throughout their life cycle, in accordance with agreed international frameworks,
-  and significantly reduce their release to air, water and soil in order to minimize
-  their adverse impacts on human health and the environment
+target: global_targets.12-4.title
 target_id: '12.4'
-graph_title: Number of parties to international multilateral environmental agreements on
-  hazardous waste, and other chemicals that meet their commitments and obligations
-  in transmitting information as required by each relevant agreement
 un_custodian_agency: UNEP
 un_designated_tier: '1'
 ---

--- a/meta/12-4-2.md
+++ b/meta/12-4-2.md
@@ -3,12 +3,10 @@ computation_units: kg per capita
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: Hazardous waste generated per capita and proportion of hazardous waste
-  treated, by type of treatment
+graph_title: global_indicators.12-4-2.title
 graph_type: line
 indicator: 12.4.2
-indicator_name: Hazardous waste generated per capita and proportion of hazardous waste
-  treated, by type of treatment
+indicator_name: global_indicators.12-4-2.title
 indicator_sort_order: 12-04-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,10 +16,7 @@ reporting_status: complete
 sdg_goal: '12'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Nature Protection of RA
-target: By 2020, achieve the environmentally sound management of chemicals and all
-  wastes throughout their life cycle, in accordance with agreed international frameworks,
-  and significantly reduce their release to air, water and soil in order to minimize
-  their adverse impacts on human health and the environment
+target: global_targets.12-4.title
 target_id: '12.4'
 un_custodian_agency: UNSD, UNEP
 un_designated_tier: '3'

--- a/meta/12-5-1.md
+++ b/meta/12-5-1.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-5-1.title
 graph_type: line
 indicator: 12.5.1
-indicator_name: National recycling rate, tons of material recycled
+indicator_name: global_indicators.12-5-1.title
 indicator_sort_order: 12-05-01
 layout: indicator
 permalink: /12-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, substantially reduce waste generation through prevention, reduction,
-  recycling and reuse
+target: global_targets.12-5.title
 target_id: '12.5'
-graph_title: National recycling rate, tons of material recycled
 un_custodian_agency: United Nations Statistics Division (UNSD), UN Environment (UNEP)
 un_designated_tier: '3'
 ---

--- a/meta/12-6-1.md
+++ b/meta/12-6-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-6-1.title
 graph_type: line
 indicator: 12.6.1
-indicator_name: Number of companies publishing sustainability reports
+indicator_name: global_indicators.12-6-1.title
 indicator_sort_order: 12-06-01
 layout: indicator
 permalink: /12-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Encourage companies, especially large and transnational companies, to adopt
-  sustainable practices and to integrate sustainability information into their reporting
-  cycle
+target: global_targets.12-6.title
 target_id: '12.6'
-graph_title: Number of companies publishing sustainability reports
 un_custodian_agency: UNEP,  UNCTAD
 un_designated_tier: '3'
 ---

--- a/meta/12-7-1.md
+++ b/meta/12-7-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-7-1.title
 graph_type: line
 indicator: 12.7.1
-indicator_name: Number of countries implementing sustainable public procurement policies
-  and action plans
+indicator_name: global_indicators.12-7-1.title
 indicator_sort_order: 12-07-01
 layout: indicator
 permalink: /12-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Promote public procurement practices that are sustainable, in accordance with
-  national policies and priorities
+target: global_targets.12-7.title
 target_id: '12.7'
-graph_title: Number of countries implementing sustainable public procurement policies and
-  action plans
 un_custodian_agency: UNEP
 un_designated_tier: '3'
 ---

--- a/meta/12-8-1.md
+++ b/meta/12-8-1.md
@@ -2,24 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-8-1.title
 graph_type: line
 indicator: 12.8.1
-indicator_name: "Extent to which (i) global citizenship education and (ii) education\
-  \ for sustainable development (including climate change education) are mainstreamed\
-  \ in (a) national education policies; (b)\_curricula; (c) teacher education; and\
-  \ (d) student assessment"
+indicator_name: global_indicators.12-8-1.title
 indicator_sort_order: 12-08-01
 layout: indicator
 permalink: /12-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: By 2030, ensure that people everywhere have the relevant information and awareness
-  for sustainable development and lifestyles in harmony with nature
+target: global_targets.12-8.title
 target_id: '12.8'
-graph_title: "Extent to which (i) global citizenship education and (ii) education for sustainable\
-  \ development (including climate change education) are mainstreamed in (a) national\
-  \ education policies; (b)\_curricula; (c) teacher education; and (d) student assessment"
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '3'
 ---

--- a/meta/12-a-1.md
+++ b/meta/12-a-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-a-1.title
 graph_type: line
 indicator: 12.a.1
-indicator_name: Amount of support to developing countries on research and development
-  for sustainable consumption and production and environmentally sound technologies
+indicator_name: global_indicators.12-a-1.title
 indicator_sort_order: 12-aa-01
 layout: indicator
 permalink: /12-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Support developing countries to strengthen their scientific and technological
-  capacity to move towards more sustainable patterns of consumption and production
+target: global_targets.12-a.title
 target_id: 12.a
-graph_title: Amount of support to developing countries on research and development for sustainable
-  consumption and production and environmentally sound technologies
 un_custodian_agency: Under discussion among agencies (OECD, UNEP,UNESCO-UIS,World
   Bank)
 un_designated_tier: '3'

--- a/meta/12-b-1.md
+++ b/meta/12-b-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-b-1.title
 graph_type: line
 indicator: 12.b.1
-indicator_name: Number of sustainable tourism strategies or policies and implemented
-  action plans with agreed monitoring and evaluation tools
+indicator_name: global_indicators.12-b-1.title
 indicator_sort_order: 12-bb-01
 layout: indicator
 permalink: /12-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Develop and implement tools to monitor sustainable development impacts for
-  sustainable tourism that creates jobs and promotes local culture and products
+target: global_targets.12-b.title
 target_id: 12.b
-graph_title: Number of sustainable tourism strategies or policies and implemented action
-  plans with agreed monitoring and evaluation tools
 un_custodian_agency: UNWTO
 un_designated_tier: '3'
 ---

--- a/meta/12-c-1.md
+++ b/meta/12-c-1.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
+graph_title: global_indicators.12-c-1.title
 graph_type: line
 indicator: 12.c.1
-indicator_name: Amount of fossil-fuel subsidies per unit of GDP (production and consumption)
-  and as a proportion of total national expenditure on fossil fuels
+indicator_name: global_indicators.12-c-1.title
 indicator_sort_order: 12-cc-01
 layout: indicator
 permalink: /12-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: Rationalize inefficient fossil-fuel subsidies that encourage wasteful consumption
-  by removing market distortions, in accordance with national circumstances, including
-  by restructuring taxation and phasing out those harmful subsidies, where they exist,
-  to reflect their environmental impacts, taking fully into account the specific needs
-  and conditions of developing countries and minimizing the possible adverse impacts
-  on their development in a manner that protects the poor and the affected communities
+target: global_targets.12-c.title
 target_id: 12.c
-graph_title: Amount of fossil-fuel subsidies per unit of GDP (production and consumption)
-  and as a proportion of total national expenditure on fossil fuels
 un_custodian_agency: UNEP
 un_designated_tier: '3'
 ---

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -3,21 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
   KB)
+graph_title: global_indicators.13-1-1.title
 graph_type: line
 indicator: 13.1.1
-indicator_name: Number of deaths, missing persons and directly affected persons attributed
-  to disasters per 100,000 population
+indicator_name: global_indicators.13-1-1.title
 indicator_sort_order: 13-01-01
 layout: indicator
 permalink: /13-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Strengthen resilience and adaptive capacity to climate-related hazards and
-  natural disasters in all countries
+target: global_targets.13-1.title
 target_id: '13.1'
-graph_title: Number of deaths, missing persons and directly affected persons attributed
-  to disasters per 100,000 population
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'
 ---

--- a/meta/13-1-2.md
+++ b/meta/13-1-2.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
+graph_title: global_indicators.13-1-2.title
 graph_type: line
 indicator: 13.1.2
-indicator_name: Number of countries that adopt and implement national disaster risk
-  reduction strategies in line with the Sendai Framework for Disaster Risk Reduction
-  2015-2030
+indicator_name: global_indicators.13-1-2.title
 indicator_sort_order: 13-01-02
 layout: indicator
 permalink: /13-1-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Strengthen resilience and adaptive capacity to climate-related hazards and
-  natural disasters in all countries
+target: global_targets.13-1.title
 target_id: '13.1'
-graph_title: Number of countries that adopt and implement national disaster risk reduction
-  strategies in line with the Sendai Framework for Disaster Risk Reduction 2015-2030
 un_custodian_agency: UNISDR
 un_designated_tier: '2'
 ---

--- a/meta/13-1-3.md
+++ b/meta/13-1-3.md
@@ -1,21 +1,18 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
+graph_title: global_indicators.13-1-3.title
 graph_type: line
 indicator: 13.1.3
-indicator_name: Proportion of local governments that adopt and implement local disaster
-  risk reduction strategies in line with national disaster risk reduction strategies
+indicator_name: global_indicators.13-1-3.title
 indicator_sort_order: 13-01-03
 layout: indicator
 permalink: /13-1-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Strengthen resilience and adaptive capacity to climate-related hazards and
-  natural disasters in all countries
+target: global_targets.13-1.title
 target_id: '13.1'
-graph_title: Proportion of local governments that adopt and implement local disaster risk
-  reduction strategies in line with national disaster risk reduction strategies
 un_custodian_agency: UNISDR
 un_designated_tier: '3'
 ---

--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -2,28 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
+graph_title: global_indicators.13-2-1.title
 graph_type: line
 indicator: 13.2.1
-indicator_name: Number of countries that have communicated the establishment or operationalization
-  of an integrated policy/strategy/plan which increases their ability to adapt to
-  the adverse impacts of climate change, and foster climate resilience and low greenhouse
-  gas emissions development in a manner that does not threaten food production (including
-  a national adaptation plan, nationally determined contribution, national communication,
-  biennial update report or other)
+indicator_name: global_indicators.13-2-1.title
 indicator_sort_order: 13-02-01
 layout: indicator
 permalink: /13-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Integrate climate change measures into national policies, strategies and planning
+target: global_targets.13-2.title
 target_id: '13.2'
-graph_title: Number of countries that have communicated the establishment or operationalization
-  of an integrated policy/strategy/plan which increases their ability to adapt to
-  the adverse impacts of climate change, and foster climate resilience and low greenhouse
-  gas emissions development in a manner that does not threaten food production (including
-  a national adaptation plan, nationally determined contribution, national communication,
-  biennial update report or other)
 un_custodian_agency: UNFCCC
 un_designated_tier: '3'
 ---

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
+graph_title: global_indicators.13-3-1.title
 graph_type: line
 indicator: 13.3.1
-indicator_name: Number of countries that have integrated mitigation, adaptation, impact
-  reduction and early warning into primary, secondary and tertiary curricula
+indicator_name: global_indicators.13-3-1.title
 indicator_sort_order: 13-03-01
 layout: indicator
 permalink: /13-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Improve education, awareness-raising and human and institutional capacity
-  on climate change mitigation, adaptation, impact reduction and early warning
+target: global_targets.13-3.title
 target_id: '13.3'
-graph_title: Number of countries that have integrated mitigation, adaptation, impact reduction
-  and early warning into primary, secondary and tertiary curricula
 un_custodian_agency: UNFCCC,UNESCO-UIS
 un_designated_tier: '3'
 ---

--- a/meta/13-3-2.md
+++ b/meta/13-3-2.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
+graph_title: global_indicators.13-3-2.title
 graph_type: line
 indicator: 13.3.2
-indicator_name: Number of countries that have communicated the strengthening of institutional,
-  systemic and individual capacity-building to implement adaptation, mitigation and
-  technology transfer, and development actions
+indicator_name: global_indicators.13-3-2.title
 indicator_sort_order: 13-03-02
 layout: indicator
 permalink: /13-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Improve education, awareness-raising and human and institutional capacity
-  on climate change mitigation, adaptation, impact reduction and early warning
+target: global_targets.13-3.title
 target_id: '13.3'
-graph_title: Number of countries that have communicated the strengthening of institutional,
-  systemic and individual capacity-building to implement adaptation, mitigation and
-  technology transfer, and development actions
 un_custodian_agency: UNFCCC,UNESCO-UIS
 un_designated_tier: '3'
 ---

--- a/meta/13-a-1.md
+++ b/meta/13-a-1.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
+graph_title: global_indicators.13-a-1.title
 graph_type: line
 indicator: 13.a.1
-indicator_name: "Mobilized amount of United States dollars per year between 2020 and\
-  \ 2025 accountable towards the $100\_billion commitment"
+indicator_name: global_indicators.13-a-1.title
 indicator_sort_order: 13-aa-01
 layout: indicator
 permalink: /13-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Implement the commitment undertaken by developed-country parties to the United
-  Nations Framework Convention on Climate Change to a goal of mobilizing jointly $100
-  billion annually by 2020 from all sources to address the needs of developing countries
-  in the context of meaningful mitigation actions and transparency on implementation
-  and fully operationalize the Green Climate Fund through its capitalization as soon
-  as possible
+target: global_targets.13-a.title
 target_id: 13.a
-graph_title: "Mobilized amount of United States dollars per year between 2020 and 2025 accountable\
-  \ towards the $100\_billion commitment"
 un_custodian_agency: UNFCCC,OECD
 un_designated_tier: '3'
 ---

--- a/meta/13-b-1.md
+++ b/meta/13-b-1.md
@@ -2,28 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
+graph_title: global_indicators.13-b-1.title
 graph_type: line
 indicator: 13.b.1
-indicator_name: Number of least developed countries and small island developing States
-  that are receiving specialized support, and amount of support, including finance,
-  technology and capacity-building, for mechanisms for raising capacities for effective
-  climate change-related planning and management, including focusing on women, youth
-  and local and marginalized communities
+indicator_name: global_indicators.13-b-1.title
 indicator_sort_order: 13-bb-01
 layout: indicator
 permalink: /13-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: Promote mechanisms for raising capacity for effective climate change-related
-  planning and management in least developed countries and small island developing
-  States, including focusing on women, youth and local and marginalized communities
+target: global_targets.13-b.title
 target_id: 13.b
-graph_title: Number of least developed countries and small island developing States that
-  are receiving specialized support, and amount of support, including finance, technology
-  and capacity-building, for mechanisms for raising capacities for effective climate
-  change-related planning and management, including focusing on women, youth and local
-  and marginalized communities
 un_custodian_agency: OHRLLS, Regional Commissions, AOSIS, SIDS, Samoa Pathway
 un_designated_tier: '3'
 ---

--- a/meta/14-1-1.md
+++ b/meta/14-1-1.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
+graph_title: global_indicators.14-1-1.title
 graph_type: line
 indicator: 14.1.1
-indicator_name: Index of coastal eutrophication and floating plastic debris density
+indicator_name: global_indicators.14-1-1.title
 indicator_sort_order: 14-01-01
 layout: indicator
 permalink: /14-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2025, prevent and significantly reduce marine pollution of all kinds, in
-  particular from land-based activities, including marine debris and nutrient pollution
+target: global_targets.14-1.title
 target_id: '14.1'
-graph_title: Index of coastal eutrophication and floating plastic debris density
 un_custodian_agency: UNEP
 un_designated_tier: '3'
 ---

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288
   kB)
+graph_title: global_indicators.14-2-1.title
 graph_type: line
 indicator: 14.2.1
-indicator_name: Proportion of national exclusive economic zones managed using ecosystem-based
-  approaches
+indicator_name: global_indicators.14-2-1.title
 indicator_sort_order: 14-02-01
 layout: indicator
 permalink: /14-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, sustainably manage and protect marine and coastal ecosystems to avoid
-  significant adverse impacts, including by strengthening their resilience, and take
-  action for their restoration in order to achieve healthy and productive oceans
+target: global_targets.14-2.title
 target_id: '14.2'
-graph_title: Proportion of national exclusive economic zones managed using ecosystem-based
-  approaches
 un_custodian_agency: UNEP
 un_designated_tier: '3'
 ---

--- a/meta/14-3-1.md
+++ b/meta/14-3-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
+graph_title: global_indicators.14-3-1.title
 graph_type: line
 indicator: 14.3.1
-indicator_name: Average marine acidity (pH) measured at agreed suite of representative
-  sampling stations
+indicator_name: global_indicators.14-3-1.title
 indicator_sort_order: 14-03-01
 layout: indicator
 permalink: /14-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: Minimize and address the impacts of ocean acidification, including through
-  enhanced scientific cooperation at all levels
+target: global_targets.14-3.title
 target_id: '14.3'
-graph_title: Average marine acidity (pH) measured at agreed suite of representative sampling
-  stations
 un_custodian_agency: 'IOC-UNESCO '
 un_designated_tier: '3'
 ---

--- a/meta/14-4-1.md
+++ b/meta/14-4-1.md
@@ -3,6 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 370
   KB)
+graph_title: global_indicators.14-4-1.title
 graph_type: line
 indicator: 14.4.1
 indicator_definition: The indicator Proportion of fish stocks within biologically
@@ -11,20 +12,15 @@ indicator_definition: The indicator Proportion of fish stocks within biologicall
   that can produce the maximum sustainable yield (MSY) is classified as biologically
   sustainable. In contrast, when abundance falls below the MSY level, the stock is
   considered biologically unsustainable.
-indicator_name: Proportion of fish stocks within biologically sustainable levels
+indicator_name: global_indicators.14-4-1.title
 indicator_sort_order: 14-04-01
 layout: indicator
 permalink: /14-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, effectively regulate harvesting and end overfishing, illegal, unreported
-  and unregulated fishing and destructive fishing practices and implement science-based
-  management plans, in order to restore fish stocks in the shortest time feasible,
-  at least to levels that can produce maximum sustainable yield as determined by their
-  biological characteristics
+target: global_targets.14-4.title
 target_id: '14.4'
-graph_title: Proportion of fish stocks within biologically sustainable levels
 un_custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
 un_designated_tier: '1'
 ---

--- a/meta/14-5-1.md
+++ b/meta/14-5-1.md
@@ -3,23 +3,22 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 293
   KB)
+graph_title: global_indicators.14-5-1.title
 graph_type: line
 indicator: 14.5.1
 indicator_definition: The indicator Coverage of protected areas in relation to marine
   areas shows temporal trends in the mean percentage of each important site for marine
   biodiversity (i.e., those that contribute significantly to the global persistence
   of biodiversity) that is covered by designated protected areas.
-indicator_name: Coverage of protected areas in relation to marine areas
+indicator_name: global_indicators.14-5-1.title
 indicator_sort_order: 14-05-01
 layout: indicator
 permalink: /14-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, conserve at least 10 per cent of coastal and marine areas, consistent
-  with national and international law and based on the best available scientific information
+target: global_targets.14-5.title
 target_id: '14.5'
-graph_title: Coverage of protected areas in relation to marine areas
 un_custodian_agency: UN Environment World Conservation Monitoring Centre (UNEP-WCMC)
   BirdLife International (BLI) International Union for Conservation of Nature (IUCN)
 un_designated_tier: '1'

--- a/meta/14-6-1.md
+++ b/meta/14-6-1.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
+graph_title: global_indicators.14-6-1.title
 graph_type: line
 indicator: 14.6.1
-indicator_name: Progress by countries in the degree of implementation of international
-  instruments aiming to combat illegal, unreported and unregulated fishing
+indicator_name: global_indicators.14-6-1.title
 indicator_sort_order: 14-06-01
 layout: indicator
 permalink: /14-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2020, prohibit certain forms of fisheries subsidies which contribute to
-  overcapacity and overfishing, eliminate subsidies that contribute to illegal, unreported
-  and unregulated fishing and refrain from introducing new such subsidies, recognizing
-  that appropriate and effective special and differential treatment for developing
-  and least developed countries should be an integral part of the World Trade Organization
-  fisheries subsidies negotiationb
+target: global_targets.14-6.title
 target_id: '14.6'
-graph_title: Progress by countries in the degree of implementation of international instruments
-  aiming to combat illegal, unreported and unregulated fishing
 un_custodian_agency: FAO
 un_designated_tier: '3'
 ---

--- a/meta/14-7-1.md
+++ b/meta/14-7-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
+graph_title: global_indicators.14-7-1.title
 graph_type: line
 indicator: 14.7.1
-indicator_name: Sustainable fisheries as a proportion of GDP in small island developing
-  States, least developed countries and all countries
+indicator_name: global_indicators.14-7-1.title
 indicator_sort_order: 14-07-01
 layout: indicator
 permalink: /14-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: By 2030, increase the economic benefits to small island developing States
-  and least developed countries from the sustainable use of marine resources, including
-  through sustainable management of fisheries, aquaculture and tourism
+target: global_targets.14-7.title
 target_id: '14.7'
-graph_title: Sustainable fisheries as a proportion of GDP in small island developing States,
-  least developed countries and all countries
 un_custodian_agency: FAO,UNEP-WCMC
 un_designated_tier: '3'
 ---

--- a/meta/14-a-1.md
+++ b/meta/14-a-1.md
@@ -2,24 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
+graph_title: global_indicators.14-a-1.title
 graph_type: line
 indicator: 14.a.1
-indicator_name: Proportion of total research budget allocated to research in the field
-  of marine technology
+indicator_name: global_indicators.14-a-1.title
 indicator_sort_order: 14-aa-01
 layout: indicator
 permalink: /14-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: Increase scientific knowledge, develop research capacity and transfer marine
-  technology, taking into account the Intergovernmental Oceanographic Commission Criteria
-  and Guidelines on the Transfer of Marine Technology, in order to improve ocean health
-  and to enhance the contribution of marine biodiversity to the development of developing
-  countries, in particular small island developing States and least developed countries
+target: global_targets.14-a.title
 target_id: 14.a
-graph_title: Proportion of total research budget allocated to research in the field of marine
-  technology
 un_custodian_agency: IOC-UNESCO
 un_designated_tier: '2'
 ---

--- a/meta/14-b-1.md
+++ b/meta/14-b-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
+graph_title: global_indicators.14-b-1.title
 graph_type: line
 indicator: 14.b.1
-indicator_name: Progress by countries in the degree of application of a legal/regulatory/policy/institutional
-  framework which recognizes and protects access rights for small-scale fisheries
+indicator_name: global_indicators.14-b-1.title
 indicator_sort_order: 14-bb-01
 layout: indicator
 permalink: /14-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: Provide access for small-scale artisanal fishers to marine resources and markets
+target: global_targets.14-b.title
 target_id: 14.b
-graph_title: Progress by countries in the degree of application of a legal/regulatory/policy/institutional
-  framework which recognizes and protects access rights for small-scale fisheries
 un_custodian_agency: FAO
 un_designated_tier: '3'
 ---

--- a/meta/14-c-1.md
+++ b/meta/14-c-1.md
@@ -2,30 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
+graph_title: global_indicators.14-c-1.title
 graph_type: line
 indicator: 14.c.1
-indicator_name: Number of countries making progress in ratifying, accepting and implementing
-  through legal, policy and institutional frameworks, ocean-related instruments that
-  implement international law, as reflected in the United Nation Convention on the
-  Law of the Sea, for the conservation and sustainable use of the oceans and their
-  resources
+indicator_name: global_indicators.14-c-1.title
 indicator_sort_order: 14-cc-01
 layout: indicator
 permalink: /14-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: "Enhance the conservation and sustainable use of oceans and their resources\
-  \ by implementing international law as reflected in the United Nations Convention\
-  \ on the Law of the Sea, which provides the legal framework for the conservation\
-  \ and sustainable use of oceans and their resources, as recalled in paragraph 158\
-  \ of \u201CThe future we want\u201D"
+target: global_targets.14-c.title
 target_id: 14.c
-graph_title: Number of countries making progress in ratifying, accepting and implementing
-  through legal, policy and institutional frameworks, ocean-related instruments that
-  implement international law, as reflected in the United Nation Convention on the
-  Law of the Sea, for the conservation and sustainable use of the oceans and their
-  resources
 un_custodian_agency: UN-DOALOS,FAO,UNEP,ILO,other UN-Oceans agencies
 un_designated_tier: '3'
 ---

--- a/meta/15-1-1.md
+++ b/meta/15-1-1.md
@@ -4,11 +4,11 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 379
   KB)
-graph_title: Forest area as a proportion of total land area
+graph_title: global_indicators.15-1-1.title
 graph_type: line
 indicator: 15.1.1
 indicator_definition: Forest area as a proportion of total land area
-indicator_name: Forest area as a proportion of total land area
+indicator_name: global_indicators.15-1-1.title
 indicator_sort_order: 15-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,9 +18,7 @@ reporting_status: complete
 sdg_goal: '15'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Nature Protection of RA
-target: Protect, restore and promote sustainable use of terrestrial ecosystems, sustainably
-  manage forests, combat desertification, and halt and reverse land degradation and
-  halt biodiversity loss
+target: global_targets.15.title
 target_id: '15'
 un_custodian_agency: Food and Agricultural Organization
 un_designated_tier: '1'

--- a/meta/15-1-2.md
+++ b/meta/15-1-2.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: Proportion of important sites for terrestrial and freshwater biodiversity
-  that are covered by protected areas, by ecosystem type
+graph_title: global_indicators.15-1-2.title
 graph_type: line
 indicator: 15.1.2
-indicator_name: Proportion of important sites for terrestrial and freshwater biodiversity
-  that are covered by protected areas, by ecosystem type
+indicator_name: global_indicators.15-1-2.title
 indicator_sort_order: 15-01-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,9 +16,7 @@ reporting_status: complete
 sdg_goal: '15'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Nature Protection of RA
-target: By 2020, ensure the conservation, restoration and sustainable use of terrestrial
-  and inland freshwater ecosystems and their services, in particular forests, wetlands,
-  mountains and drylands, in line with obligations under international agreements
+target: global_targets.15-1.title
 target_id: '15.1'
 un_custodian_agency: UNEP-WCMC,UNEP
 un_designated_tier: '1'

--- a/meta/15-2-1.md
+++ b/meta/15-2-1.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-15-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 756
   KB)
+graph_title: global_indicators.15-2-1.title
 graph_type: line
 indicator: 15.2.1
-indicator_name: Progress towards sustainable forest management
+indicator_name: global_indicators.15-2-1.title
 indicator_sort_order: 15-02-01
 layout: indicator
 permalink: /15-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2020, promote the implementation of sustainable management of all types
-  of forests, halt deforestation, restore degraded forests and substantially increase
-  afforestation and reforestation globally
+target: global_targets.15-2.title
 target_id: '15.2'
-graph_title: Progress towards sustainable forest management
 un_custodian_agency: Food and Agriculture Organisation of the United Nations (FAO)
 un_designated_tier: '1'
 ---

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: Proportion of land that is degraded over total land area
+graph_title: global_indicators.15-3-1.title
 graph_type: line
 indicator: 15.3.1
-indicator_name: Proportion of land that is degraded over total land area
+indicator_name: global_indicators.15-3-1.title
 indicator_sort_order: 15-03-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ sdg_goal: '15'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Agriculture of RA, Ministry of Nature
   Protection of RA,  National  Academy of Sciences of RA
-target: By 2030, combat desertification, restore degraded land and soil, including
-  land affected by desertification, drought and floods, and strive to achieve a land
-  degradation-neutral world
+target: global_targets.15-3.title
 target_id: '15.3'
 un_custodian_agency: UNCCD
 un_designated_tier: '3'

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
+graph_title: global_indicators.15-4-1.title
 graph_type: line
 indicator: 15.4.1
-indicator_name: Coverage by protected areas of important sites for mountain biodiversity
+indicator_name: global_indicators.15-4-1.title
 indicator_sort_order: 15-04-01
 layout: indicator
 permalink: /15-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2030, ensure the conservation of mountain ecosystems, including their biodiversity,
-  in order to enhance their capacity to provide benefits that are essential for sustainable
-  development
+target: global_targets.15-4.title
 target_id: '15.4'
-graph_title: Coverage by protected areas of important sites for mountain biodiversity
 un_custodian_agency: UNEP-WCMC,UNEP
 un_designated_tier: '1'
 ---

--- a/meta/15-4-2.md
+++ b/meta/15-4-2.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 384
   KB)
+graph_title: global_indicators.15-4-2.title
 graph_type: line
 indicator: 15.4.2
-indicator_name: Mountain Green Cover Index
+indicator_name: global_indicators.15-4-2.title
 indicator_sort_order: 15-04-02
 layout: indicator
 permalink: /15-4-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2030, ensure the conservation of mountain ecosystems, including their biodiversity,
-  in order to enhance their capacity to provide benefits that are essential for sustainable
-  development
+target: global_targets.15-4.title
 target_id: '15.4'
-graph_title: Mountain Green Cover Index
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '1'
 ---

--- a/meta/15-5-1.md
+++ b/meta/15-5-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 440
   KB)
+graph_title: global_indicators.15-5-1.title
 graph_type: line
 indicator: 15.5.1
-indicator_name: Red List Index
+indicator_name: global_indicators.15-5-1.title
 indicator_sort_order: 15-05-01
 layout: indicator
 permalink: /15-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Take urgent and significant action to reduce the degradation of natural habitats,
-  halt the loss of biodiversity and, by 2020, protect and prevent the extinction of
-  threatened species
+target: global_targets.15-5.title
 target_id: '15.5'
-graph_title: Red List Index
 un_custodian_agency: International Union for Conservation of Nature (IUCN) BirdLife
   International (BLI)
 un_designated_tier: '1'

--- a/meta/15-6-1.md
+++ b/meta/15-6-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
+graph_title: global_indicators.15-6-1.title
 graph_type: line
 indicator: 15.6.1
-indicator_name: Number of countries that have adopted legislative, administrative
-  and policy frameworks to ensure fair and equitable sharing of benefits
+indicator_name: global_indicators.15-6-1.title
 indicator_sort_order: 15-06-01
 layout: indicator
 permalink: /15-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Promote fair and equitable sharing of the benefits arising from the utilization
-  of genetic resources and promote appropriate access to such resources, as internationally
-  agreed
+target: global_targets.15-6.title
 target_id: '15.6'
-graph_title: Number of countries that have adopted legislative, administrative and policy
-  frameworks to ensure fair and equitable sharing of benefits
 un_custodian_agency: CBD-Secretariat
 un_designated_tier: '1'
 ---

--- a/meta/15-7-1.md
+++ b/meta/15-7-1.md
@@ -3,19 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
+graph_title: global_indicators.15-7-1.title
 graph_type: line
 indicator: 15.7.1
-indicator_name: Proportion of traded wildlife that was poached or illicitly trafficked
+indicator_name: global_indicators.15-7-1.title
 indicator_sort_order: 15-07-01
 layout: indicator
 permalink: /15-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Take urgent action to end poaching and trafficking of protected species of
-  flora and fauna and address both demand and supply of illegal wildlife products
+target: global_targets.15-7.title
 target_id: '15.7'
-graph_title: Proportion of traded wildlife that was poached or illicitly trafficked
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '2'
 ---

--- a/meta/15-8-1.md
+++ b/meta/15-8-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
+graph_title: global_indicators.15-8-1.title
 graph_type: line
 indicator: 15.8.1
-indicator_name: Proportion of countries adopting relevant national legislation and
-  adequately resourcing the prevention or control of invasive alien species
+indicator_name: global_indicators.15-8-1.title
 indicator_sort_order: 15-08-01
 layout: indicator
 permalink: /15-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2020, introduce measures to prevent the introduction and significantly
-  reduce the impact of invasive alien species on land and water ecosystems and control
-  or eradicate the priority species
+target: global_targets.15-8.title
 target_id: '15.8'
-graph_title: Proportion of countries adopting relevant national legislation and adequately
-  resourcing the prevention or control of invasive alien species
 un_custodian_agency: IUCN
 un_designated_tier: '2'
 ---

--- a/meta/15-9-1.md
+++ b/meta/15-9-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
+graph_title: global_indicators.15-9-1.title
 graph_type: line
 indicator: 15.9.1
-indicator_name: Progress towards national targets established in accordance with Aichi
-  Biodiversity Target 2 of the Strategic Plan for Biodiversity 2011-2020
+indicator_name: global_indicators.15-9-1.title
 indicator_sort_order: 15-09-01
 layout: indicator
 permalink: /15-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: By 2020, integrate ecosystem and biodiversity values into national and local
-  planning, development processes, poverty reduction strategies and accounts
+target: global_targets.15-9.title
 target_id: '15.9'
-graph_title: Progress towards national targets established in accordance with Aichi Biodiversity
-  Target 2 of the Strategic Plan for Biodiversity 2011-2020
 un_custodian_agency: CBD-Secretariat,UNEP
 un_designated_tier: '3'
 ---

--- a/meta/15-a-1.md
+++ b/meta/15-a-1.md
@@ -3,23 +3,20 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.15-a-1.title
 graph_type: line
 indicator: 15.a.1
 indicator_definition: Total ODA flows to developing countries quantify the public
   effort that donors provide to developing countries for biodiversity.
-indicator_name: Official development assistance and public expenditure on conservation
-  and sustainable use of biodiversity and ecosystems
+indicator_name: global_indicators.15-a-1.title
 indicator_sort_order: 15-aa-01
 layout: indicator
 permalink: /15-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Mobilize and significantly increase financial resources from all sources to
-  conserve and sustainably use biodiversity and ecosystems
+target: global_targets.15-a.title
 target_id: 15.a
-graph_title: Official development assistance and public expenditure on conservation and
-  sustainable use of biodiversity and ecosystems
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1/3
 ---

--- a/meta/15-b-1.md
+++ b/meta/15-b-1.md
@@ -3,24 +3,20 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.15-b-1.title
 graph_type: line
 indicator: 15.b.1
 indicator_definition: Total ODA flows to developing countries quantify the public
   effort that donors provide to developing countries for biodiversity.
-indicator_name: Official development assistance and public expenditure on conservation
-  and sustainable use of biodiversity and ecosystems
+indicator_name: global_indicators.15-b-1.title
 indicator_sort_order: 15-bb-01
 layout: indicator
 permalink: /15-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Mobilize significant resources from all sources and at all levels to finance
-  sustainable forest management and provide adequate incentives to developing countries
-  to advance such management, including for conservation and reforestation
+target: global_targets.15-b.title
 target_id: 15.b
-graph_title: Official development assistance and public expenditure on conservation and
-  sustainable use of biodiversity and ecosystems
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1/3
 ---

--- a/meta/15-c-1.md
+++ b/meta/15-c-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
+graph_title: global_indicators.15-c-1.title
 graph_type: line
 indicator: 15.c.1
-indicator_name: Proportion of traded wildlife that was poached or illicitly trafficked
+indicator_name: global_indicators.15-c-1.title
 indicator_sort_order: 15-cc-01
 layout: indicator
 permalink: /15-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: Enhance global support for efforts to combat poaching and trafficking of protected
-  species, including by increasing the capacity of local communities to pursue sustainable
-  livelihood opportunities
+target: global_targets.15-c.title
 target_id: 15.c
-graph_title: Proportion of traded wildlife that was poached or illicitly trafficked
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '2'
 ---

--- a/meta/16-1-1.md
+++ b/meta/16-1-1.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 222
   KB)
+graph_title: global_indicators.16-1-1.title
 graph_type: line
 indicator: 16.1.1
-indicator_name: Number of victims of intentional homicide per 100,000 population,
-  by sex and age
+indicator_name: global_indicators.16-1-1.title
 indicator_sort_order: 16-01-01
 layout: indicator
 permalink: /16-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Significantly reduce all forms of violence and related death rates everywhere
+target: global_targets.16-1.title
 target_id: '16.1'
-graph_title: Number of victims of intentional homicide per 100,000 population, by sex and
-  age
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC) World Health
   Organization (WHO)
 un_designated_tier: '1'

--- a/meta/16-1-2.md
+++ b/meta/16-1-2.md
@@ -3,18 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 1.3
   MB)
+graph_title: global_indicators.16-1-2.title
 graph_type: line
 indicator: 16.1.2
-indicator_name: Conflict-related deaths per 100,000 population, by sex, age and cause
+indicator_name: global_indicators.16-1-2.title
 indicator_sort_order: 16-01-02
 layout: indicator
 permalink: /16-1-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Significantly reduce all forms of violence and related death rates everywhere
+target: global_targets.16-1.title
 target_id: '16.1'
-graph_title: Conflict-related deaths per 100,000 population, by sex, age and cause
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)
 un_designated_tier: '3'

--- a/meta/16-1-3.md
+++ b/meta/16-1-3.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-03.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 217
   KB)
+graph_title: global_indicators.16-1-3.title
 graph_type: line
 indicator: 16.1.3
-indicator_name: 16.1.3 Proportion of population subjected to physical, psychological
-  or sexual violence in the previous 12 months
+indicator_name: global_indicators.16-1-3.title
 indicator_sort_order: 16-01-03
 layout: indicator
 permalink: /16-1-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: 16.1 Significantly reduce all forms of violence and related death rates everywhere
+target: global_targets.16-1.title
 target_id: '16.1'
-graph_title: Proportion of population subjected to physical, psychological or sexual violence
-  in the previous 12 months
 un_custodian_agency: UNODC
 un_designated_tier: '2'
 ---

--- a/meta/16-1-4.md
+++ b/meta/16-1-4.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213
   KB)
+graph_title: global_indicators.16-1-4.title
 graph_type: line
 indicator: 16.1.4
-indicator_name: 16.1.4 Proportion of population that feel safe walking alone around
-  the area they live
+indicator_name: global_indicators.16-1-4.title
 indicator_sort_order: 16-01-04
 layout: indicator
 permalink: /16-1-4/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: 16.1 Significantly reduce all forms of violence and related death rates everywhere
+target: global_targets.16-1.title
 target_id: '16.1'
-graph_title: Proportion of population that feel safe walking alone around the area they
-  live
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: 2
 ---

--- a/meta/16-10-1.md
+++ b/meta/16-10-1.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-10-1.title
 graph_type: line
 indicator: 16.10.1
-indicator_name: Number of verified cases of killing, kidnapping, enforced disappearance,
-  arbitrary detention and torture of journalists, associated media personnel, trade
-  unionists and human rights advocates in the previous 12 months
+indicator_name: global_indicators.16-10-1.title
 indicator_sort_order: 16-10-01
 layout: indicator
 permalink: /16-10-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure public access to information and protect fundamental freedoms, in accordance
-  with national legislation and international agreements
+target: global_targets.16-10.title
 target_id: '16.10'
-graph_title: Number of verified cases of killing, kidnapping, enforced disappearance, arbitrary
-  detention and torture of journalists, associated media personnel, trade unionists
-  and human rights advocates in the previous 12 months
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)
 un_designated_tier: '2'

--- a/meta/16-10-2.md
+++ b/meta/16-10-2.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-10-2.title
 graph_type: line
 indicator: 16.10.2
-indicator_name: Number of countries that adopt and implement constitutional, statutory
-  and/or policy guarantees for public access to information
+indicator_name: global_indicators.16-10-2.title
 indicator_sort_order: 16-10-02
 layout: indicator
 permalink: /16-10-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure public access to information and protect fundamental freedoms, in accordance
-  with national legislation and international agreements
+target: global_targets.16-10.title
 target_id: '16.10'
-graph_title: Number of countries that adopt and implement constitutional, statutory and/or
-  policy guarantees for public access to information
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '2'
 ---

--- a/meta/16-2-1.md
+++ b/meta/16-2-1.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: Proportion of children aged 1-17 years who experienced any physical punishment
-  and/or psychological aggression by caregivers in the past month
+graph_title: global_indicators.16-2-1.title
 graph_type: line
 indicator: 16.2.1
-indicator_name: Proportion of children aged 1-17 years who experienced any physical
-  punishment and/or psychological aggression by caregivers in the past month
+indicator_name: global_indicators.16-2-1.title
 indicator_sort_order: 16-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +16,7 @@ reporting_status: complete
 sdg_goal: '16'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: End abuse, exploitation, trafficking and all forms of violence against and
-  torture of children
+target: global_targets.16-2.title
 target_id: '16.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '2'

--- a/meta/16-2-2.md
+++ b/meta/16-2-2.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-2-2.title
 graph_type: line
 indicator: 16.2.2
-indicator_name: Number of victims of human trafficking per 100,000 population, by
-  sex, age and form of exploitation
+indicator_name: global_indicators.16-2-2.title
 indicator_sort_order: 16-02-02
 layout: indicator
 permalink: /16-2-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: End abuse, exploitation, trafficking and all forms of violence against and
-  torture of children
+target: global_targets.16-2.title
 target_id: '16.2'
-graph_title: Number of victims of human trafficking per 100,000 population, by sex, age
-  and form of exploitation
 un_custodian_agency: UNODC
 un_designated_tier: '2'
 ---

--- a/meta/16-2-3.md
+++ b/meta/16-2-3.md
@@ -3,6 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208
   KB)
+graph_title: global_indicators.16-2-3.title
 graph_type: line
 indicator: 16.2.3
 indicator_definition: This indicator provides the proportion of young women and men
@@ -10,19 +11,15 @@ indicator_definition: This indicator provides the proportion of young women and 
   is calculated by dividing the number of young women and men aged 18-24 years who
   report having experienced any sexual violence by age 18 by the total number of young
   women and men aged 18-24 years, respectively, in the population
-indicator_name: Proportion of young women and men aged 18-29 years who experienced
-  sexual violence by age 18
+indicator_name: global_indicators.16-2-3.title
 indicator_sort_order: 16-02-03
 layout: indicator
 permalink: /16-2-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: End abuse, exploitation, trafficking and all forms of violence against and
-  torture of children
+target: global_targets.16-2.title
 target_id: '16.2'
-graph_title: Proportion of young women and men aged 18-29 years who experienced sexual violence
-  by age 18
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '2'
 ---

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-3-1.title
 graph_type: line
 indicator: 16.3.1
-indicator_name: Proportion of victims of violence in the previous 12 months who reported
-  their victimization to competent authorities or other officially recognized conflict
-  resolution mechanisms
+indicator_name: global_indicators.16-3-1.title
 indicator_sort_order: 16-03-01
 layout: indicator
 permalink: /16-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Promote the rule of law at the national and international levels and ensure
-  equal access to justice for all
+target: global_targets.16-3.title
 target_id: '16.3'
-graph_title: Proportion of victims of violence in the previous 12 months who reported their
-  victimization to competent authorities or other officially recognized conflict resolution
-  mechanisms
 un_custodian_agency: UNODC
 un_designated_tier: '2'
 ---

--- a/meta/16-3-2.md
+++ b/meta/16-3-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 209
   KB)
-graph_title: Unsentenced detainees as a proportion of overall prison population
+graph_title: global_indicators.16-3-2.title
 graph_type: line
 indicator: 16.3.2
-indicator_name: Unsentenced detainees as a proportion of overall prison population
+indicator_name: global_indicators.16-3-2.title
 indicator_sort_order: 16-03-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,8 +17,7 @@ reporting_status: complete
 sdg_goal: '16'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Justice of RA
-target: Promote the rule of law at the national and international levels and ensure
-  equal access to justice for all
+target: global_targets.16-3.title
 target_id: '16.3'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '1'

--- a/meta/16-4-1.md
+++ b/meta/16-4-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-4-1.title
 graph_type: line
 indicator: 16.4.1
-indicator_name: Total value of inward and outward illicit financial flows (in current
-  United States dollars)
+indicator_name: global_indicators.16-4-1.title
 indicator_sort_order: 16-04-01
 layout: indicator
 permalink: /16-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: By 2030, significantly reduce illicit financial and arms flows, strengthen
-  the recovery and return of stolen assets and combat all forms of organized crime
+target: global_targets.16-4.title
 target_id: '16.4'
-graph_title: Total value of inward and outward illicit financial flows (in current United
-  States dollars)
 un_custodian_agency: UNODC,UNCTAD
 un_designated_tier: '3'
 ---

--- a/meta/16-4-2.md
+++ b/meta/16-4-2.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-4-2.title
 graph_type: line
 indicator: 16.4.2
-indicator_name: Proportion of seized, found or surrendered arms whose illicit origin
-  or context has been traced or established by a competent authority in line with
-  international instruments
+indicator_name: global_indicators.16-4-2.title
 indicator_sort_order: 16-04-02
 layout: indicator
 permalink: /16-4-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: By 2030, significantly reduce illicit financial and arms flows, strengthen
-  the recovery and return of stolen assets and combat all forms of organized crime
+target: global_targets.16-4.title
 target_id: '16.4'
-graph_title: Proportion of seized, found or surrendered arms whose illicit origin or context
-  has been traced or established by a competent authority in line with international
-  instruments
 un_custodian_agency: UNODC,UNODA
 un_designated_tier: '3'
 ---

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-5-1.title
 graph_type: line
 indicator: 16.5.1
-indicator_name: Proportion of persons who had at least one contact with a public official
-  and who paid a bribe to a public official, or were asked for a bribe by those public
-  officials, during the previous 12 months
+indicator_name: global_indicators.16-5-1.title
 indicator_sort_order: 16-05-01
 layout: indicator
 permalink: /16-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Substantially reduce corruption and bribery in all their forms
+target: global_targets.16-5.title
 target_id: '16.5'
-graph_title: Proportion of persons who had at least one contact with a public official and
-  who paid a bribe to a public official, or were asked for a bribe by those public
-  officials, during the previous 12 months
 un_custodian_agency: UNODC
 un_designated_tier: '2'
 ---

--- a/meta/16-5-2.md
+++ b/meta/16-5-2.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-5-2.title
 graph_type: line
 indicator: 16.5.2
-indicator_name: Proportion of businesses that had at least one contact with a public
-  official and that paid a bribe to a public official, or were asked for a bribe by
-  those public officials during the previous 12 months
+indicator_name: global_indicators.16-5-2.title
 indicator_sort_order: 16-05-02
 layout: indicator
 permalink: /16-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Substantially reduce corruption and bribery in all their forms
+target: global_targets.16-5.title
 target_id: '16.5'
-graph_title: Proportion of businesses that had at least one contact with a public official
-  and that paid a bribe to a public official, or were asked for a bribe by those public
-  officials during the previous 12 months
 un_custodian_agency: World Bank,UNODC
 un_designated_tier: '2'
 ---

--- a/meta/16-6-1.md
+++ b/meta/16-6-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-6-1.title
 graph_type: line
 indicator: 16.6.1
-indicator_name: "Primary government expenditures as a proportion of original approved\
-  \ budget, by sector (or\_by budget codes or similar)"
+indicator_name: global_indicators.16-6-1.title
 indicator_sort_order: 16-06-01
 layout: indicator
 permalink: /16-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Develop effective, accountable and transparent institutions at all levels
+target: global_targets.16-6.title
 target_id: '16.6'
-graph_title: "Primary government expenditures as a proportion of original approved budget,\
-  \ by sector (or\_by budget codes or similar)"
 un_custodian_agency: World Bank
 un_designated_tier: '1'
 ---

--- a/meta/16-6-2.md
+++ b/meta/16-6-2.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-6-2.title
 graph_type: line
 indicator: 16.6.2
-indicator_name: Proportion of population satisfied with their last experience of public
-  services
+indicator_name: global_indicators.16-6-2.title
 indicator_sort_order: 16-06-02
 layout: indicator
 permalink: /16-6-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Develop effective, accountable and transparent institutions at all levels
+target: global_targets.16-6.title
 target_id: '16.6'
-graph_title: Proportion of population satisfied with their last experience of public services
 un_custodian_agency: UNDP
 un_designated_tier: '3'
 ---

--- a/meta/16-7-1.md
+++ b/meta/16-7-1.md
@@ -3,26 +3,21 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.16-7-1.title
 graph_type: line
 indicator: 16.7.1
 indicator_definition: In order that decision-making be responsive, inclusive, participatory
   and representative, it is important to ensure diversity in representation at all
   levels of State institutions (central, regional and local).
-indicator_name: Proportions of positions (by sex, age, persons with disabilities and
-  population groups) in public institutions (national and local legislatures, public
-  service, and judiciary) compared to national distributions
+indicator_name: global_indicators.16-7-1.title
 indicator_sort_order: 16-07-01
 layout: indicator
 permalink: /16-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure responsive, inclusive, participatory and representative decision-making
-  at all levels
+target: global_targets.16-7.title
 target_id: '16.7'
-graph_title: Proportions of positions (by sex, age, persons with disabilities and population
-  groups) in public institutions (national and local legislatures, public service,
-  and judiciary) compared to national distributions
 un_custodian_agency: United Nations Development Programme (UNDP)
 un_designated_tier: '3'
 ---

--- a/meta/16-7-2.md
+++ b/meta/16-7-2.md
@@ -3,21 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/tierIII-indicators/files/Tier3-16-07-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Tier 3 Work Plan
   (PDF 77.8 KB)
+graph_title: global_indicators.16-7-2.title
 graph_type: line
 indicator: 16.7.2
-indicator_name: Proportion of population who believe decision-making is inclusive
-  and responsive, by sex, age, disability and population group
+indicator_name: global_indicators.16-7-2.title
 indicator_sort_order: 16-07-02
 layout: indicator
 permalink: /16-7-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Ensure responsive, inclusive, participatory and representative decision-making
-  at all levels
+target: global_targets.16-7.title
 target_id: '16.7'
-graph_title: Proportion of population who believe decision-making is inclusive and responsive,
-  by sex, age, disability and population group
 un_custodian_agency: United Nations Development Programme (UNDP)
 un_designated_tier: '3'
 ---

--- a/meta/16-8-1.md
+++ b/meta/16-8-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
+graph_title: global_indicators.16-8-1.title
 graph_type: line
 indicator: 16.8.1
-indicator_name: Proportion of members and voting rights of developing countries in
-  international organizations
+indicator_name: global_indicators.16-8-1.title
 indicator_sort_order: 16-08-01
 layout: indicator
 permalink: /16-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Broaden and strengthen the participation of developing countries in the institutions
-  of global governance
+target: global_targets.16-8.title
 target_id: '16.8'
-graph_title: Proportion of members and voting rights of developing countries in international
-  organizations
 un_custodian_agency: DESA/FFDO
 un_designated_tier: '1'
 ---

--- a/meta/16-9-1.md
+++ b/meta/16-9-1.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-09-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: Proportion of children under 5 years of age whose births have been registered
-  with a civil authority, by age
+graph_title: global_indicators.16-9-1.title
 graph_type: line
 indicator: 16.9.1
-indicator_name: Proportion of children under 5 years of age whose births have been
-  registered with a civil authority, by age
+indicator_name: global_indicators.16-9-1.title
 indicator_sort_order: 16-09-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,7 +16,7 @@ reporting_status: complete
 sdg_goal: '16'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: By 2030, provide legal identity for all, including birth registration
+target: global_targets.16-9.title
 target_id: '16.9'
 un_custodian_agency: United Nations Statistics Division (UNSD), United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/16-a-1.md
+++ b/meta/16-a-1.md
@@ -3,12 +3,10 @@ computation_units: yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: Existence of independent national human rights institutions in compliance
-  with the Paris Principles
+graph_title: global_indicators.16-a-1.title
 graph_type: line
 indicator: 16.a.1
-indicator_name: Existence of independent national human rights institutions in compliance
-  with the Paris Principles
+indicator_name: global_indicators.16-a-1.title
 indicator_sort_order: 16-aa-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,9 +16,7 @@ reporting_status: complete
 sdg_goal: '16'
 source_active_1: true
 source_organisation_1: Human Rights Defender of RA (OMBUDSMAN)
-target: Strengthen relevant national institutions, including through international
-  cooperation, for building capacity at all levels, in particular in developing countries,
-  to prevent violence and combat terrorism and crime
+target: global_targets.16-a.title
 target_id: 16.a
 un_custodian_agency: OHCHR
 un_designated_tier: '1'

--- a/meta/16-b-1.md
+++ b/meta/16-b-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.16-b-1.title
 graph_type: line
 indicator: 16.b.1
-indicator_name: Proportion of population reporting having personally felt discriminated
-  against or harassed in the previous 12 months on the basis of a ground of discrimination
-  prohibited under international human rights law
+indicator_name: global_indicators.16-b-1.title
 indicator_sort_order: 16-bb-01
 layout: indicator
 permalink: /16-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: Promote and enforce non-discriminatory laws and policies for sustainable development
+target: global_targets.16-b.title
 target_id: 16.b
-graph_title: Proportion of population reporting having personally felt discriminated against
-  or harassed in the previous 12 months on the basis of a ground of discrimination
-  prohibited under international human rights law
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)
 un_designated_tier: '3'

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469
   KB)
-graph_title: Total government revenue as a proportion of GDP, by source
+graph_title: global_indicators.17-1-1.title
 graph_type: line
 indicator: 17.1.1
-indicator_name: Total government revenue as a proportion of GDP, by source
+indicator_name: global_indicators.17-1-1.title
 indicator_sort_order: 17-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Finance of RA
-target: Strengthen domestic resource mobilization, including through international
-  support to developing countries, to improve domestic capacity for tax and other
-  revenue collection
+target: global_targets.17-1.title
 target_id: '17.1'
 un_custodian_agency: International Monetary Fund (IMF)
 un_designated_tier: '1'

--- a/meta/17-1-2.md
+++ b/meta/17-1-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469
   KB)
-graph_title: Proportion of domestic budget funded by domestic taxes
+graph_title: global_indicators.17-1-2.title
 graph_type: line
 indicator: 17.1.2
-indicator_name: Proportion of domestic budget funded by domestic taxes
+indicator_name: global_indicators.17-1-2.title
 indicator_sort_order: 17-01-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Finance of RA
-target: Strengthen domestic resource mobilization, including through international
-  support to developing countries, to improve domestic capacity for tax and other
-  revenue collection
+target: global_targets.17-1.title
 target_id: '17.1'
 un_custodian_agency: International Monetary Fund (IMF)
 un_designated_tier: '1'

--- a/meta/17-10-1.md
+++ b/meta/17-10-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-10-1.title
 graph_type: line
 indicator: 17.10.1
-indicator_name: Worldwide weighted tariff-average
+indicator_name: global_indicators.17-10-1.title
 indicator_sort_order: 17-10-01
 layout: indicator
 permalink: /17-10-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: "Promote a universal, rules-based, open, non\u2011discriminatory and equitable\
-  \ multilateral trading system under the World Trade Organization, including through\
-  \ the conclusion of negotiations under its Doha Development Agenda"
+target: global_targets.17-10.title
 target_id: '17.10'
-graph_title: Worldwide weighted tariff-average
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'
 ---

--- a/meta/17-11-1.md
+++ b/meta/17-11-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-11-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-11-1.title
 graph_type: line
 indicator: 17.11.1
-indicator_name: "Developing countries\u2019 and least developed countries\u2019 share\
-  \ of global exports"
+indicator_name: global_indicators.17-11-1.title
 indicator_sort_order: 17-11-01
 layout: indicator
 permalink: /17-11-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: "Significantly increase the exports of developing countries, in particular\
-  \ with a view to doubling the least developed countries\u2019 share of global exports\
-  \ by 2020"
+target: global_targets.17-11.title
 target_id: '17.11'
-graph_title: "Developing countries\u2019 and least developed countries\u2019 share of global\
-  \ exports"
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'
 ---

--- a/meta/17-12-1.md
+++ b/meta/17-12-1.md
@@ -2,24 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-12-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-12-1.title
 graph_type: line
 indicator: 17.12.1
-indicator_name: Average tariffs faced by developing countries, least developed countries
-  and small island developing States
+indicator_name: global_indicators.17-12-1.title
 indicator_sort_order: 17-12-01
 layout: indicator
 permalink: /17-12-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Realize timely implementation of duty-free and quota-free market access on
-  a lasting basis for all least developed countries, consistent with World Trade Organization
-  decisions, including by ensuring that preferential rules of origin applicable to
-  imports from least developed countries are transparent and simple, and contribute
-  to facilitating market access
+target: global_targets.17-12.title
 target_id: '17.12'
-graph_title: Average tariffs faced by developing countries, least developed countries and
-  small island developing States
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'
 ---

--- a/meta/17-13-1.md
+++ b/meta/17-13-1.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-13-1.title
 graph_type: line
 indicator: 17.13.1
-indicator_name: Macroeconomic Dashboard
+indicator_name: global_indicators.17-13-1.title
 indicator_sort_order: 17-13-01
 layout: indicator
 permalink: /17-13-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance global macroeconomic stability, including through policy coordination
-  and policy coherence
+target: global_targets.17-13.title
 target_id: '17.13'
-graph_title: Macroeconomic Dashboard
 un_custodian_agency: World Bank
 un_designated_tier: '3'
 ---

--- a/meta/17-14-1.md
+++ b/meta/17-14-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-14-1.title
 graph_type: line
 indicator: 17.14.1
-indicator_name: Number of countries with mechanisms in place to enhance policy coherence
-  of sustainable development
+indicator_name: global_indicators.17-14-1.title
 indicator_sort_order: 17-14-01
 layout: indicator
 permalink: /17-14-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance policy coherence for sustainable development
+target: global_targets.17-14.title
 target_id: '17.14'
-graph_title: Number of countries with mechanisms in place to enhance policy coherence of
-  sustainable development
 un_custodian_agency: UNEP
 un_designated_tier: '3'
 ---

--- a/meta/17-15-1.md
+++ b/meta/17-15-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-15-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-15-1.title
 graph_type: line
 indicator: 17.15.1
-indicator_name: Extent of use of country-owned results frameworks and planning tools
-  by providers of development cooperation
+indicator_name: global_indicators.17-15-1.title
 indicator_sort_order: 17-15-01
 layout: indicator
 permalink: /17-15-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: "Respect each country\u2019s policy space and leadership to establish and\
-  \ implement policies for poverty eradication and sustainable development"
+target: global_targets.17-15.title
 target_id: '17.15'
-graph_title: Extent of use of country-owned results frameworks and planning tools by providers
-  of development cooperation
 un_custodian_agency: OECD, UNDP
 un_designated_tier: '2'
 ---

--- a/meta/17-16-1.md
+++ b/meta/17-16-1.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-16-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-16-1.title
 graph_type: line
 indicator: 17.16.1
-indicator_name: Number of countries reporting progress in multi-stakeholder development
-  effectiveness monitoring frameworks that support the achievement of the sustainable
-  development goals
+indicator_name: global_indicators.17-16-1.title
 indicator_sort_order: 17-16-01
 layout: indicator
 permalink: /17-16-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance the Global Partnership for Sustainable Development, complemented by
-  multi-stakeholder partnerships that mobilize and share knowledge, expertise, technology
-  and financial resources, to support the achievement of the Sustainable Development
-  Goals in all countries, in particular developing countries
+target: global_targets.17-16.title
 target_id: '17.16'
-graph_title: Number of countries reporting progress in multi-stakeholder development effectiveness
-  monitoring frameworks that support the achievement of the sustainable development
-  goals
 un_custodian_agency: OECD, UNDP
 un_designated_tier: '2'
 ---

--- a/meta/17-17-1.md
+++ b/meta/17-17-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-17-1.title
 graph_type: line
 indicator: 17.17.1
-indicator_name: Amount of United States dollars committed to public-private and civil
-  society partnerships
+indicator_name: global_indicators.17-17-1.title
 indicator_sort_order: 17-17-01
 layout: indicator
 permalink: /17-17-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Encourage and promote effective public, public-private and civil society partnerships,
-  building on the experience and resourcing strategies of partnerships
+target: global_targets.17-17.title
 target_id: '17.17'
-graph_title: Amount of United States dollars committed to public-private and civil society
-  partnerships
 un_custodian_agency: World Bank
 un_designated_tier: '3'
 ---

--- a/meta/17-18-1.md
+++ b/meta/17-18-1.md
@@ -3,14 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: Proportion of sustainable development indicators produced at the national
-  level with full disaggregation when relevant to the target, in accordance with the
-  Fundamental Principles of Official Statistics
+graph_title: global_indicators.17-18-1.title
 graph_type: line
 indicator: 17.18.1
-indicator_name: Proportion of sustainable development indicators produced at the national
-  level with full disaggregation when relevant to the target, in accordance with the
-  Fundamental Principles of Official Statistics
+indicator_name: global_indicators.17-18-1.title
 indicator_sort_order: 17-18-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -20,11 +16,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2020, enhance capacity-building support to developing countries, including
-  for least developed countries and small island developing States, to increase significantly
-  the availability of high-quality, timely and reliable data disaggregated by income,
-  gender, age, race, ethnicity, migratory status, disability, geographic location
-  and other characteristics relevant in national contexts
+target: global_targets.17-18.title
 target_id: '17.18'
 un_custodian_agency: UNSD
 un_designated_tier: '3'

--- a/meta/17-18-2.md
+++ b/meta/17-18-2.md
@@ -3,12 +3,10 @@ computation_units: yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: Number of countries that have national statistical legislation that complies
-  with the Fundamental Principles of Official Statistics
+graph_title: global_indicators.17-18-2.title
 graph_type: line
 indicator: 17.18.2
-indicator_name: Number of countries that have national statistical legislation that
-  complies with the Fundamental Principles of Official Statistics
+indicator_name: global_indicators.17-18-2.title
 indicator_sort_order: 17-18-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,11 +16,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2020, enhance capacity-building support to developing countries, including
-  for least developed countries and small island developing States, to increase significantly
-  the availability of high-quality, timely and reliable data disaggregated by income,
-  gender, age, race, ethnicity, migratory status, disability, geographic location
-  and other characteristics relevant in national contexts
+target: global_targets.17-18.title
 target_id: '17.18'
 un_custodian_agency: UNSD,PARIS21, Regional Commissions,World Bank
 un_designated_tier: '2'

--- a/meta/17-18-3.md
+++ b/meta/17-18-3.md
@@ -3,12 +3,10 @@ computation_units: yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: Number of countries with a national statistical plan that is fully funded
-  and under implementation, by source of funding
+graph_title: global_indicators.17-18-3.title
 graph_type: line
 indicator: 17.18.3
-indicator_name: Number of countries with a national statistical plan that is fully
-  funded and under implementation, by source of funding
+indicator_name: global_indicators.17-18-3.title
 indicator_sort_order: 17-18-03
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,11 +16,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2020, enhance capacity-building support to developing countries, including
-  for least developed countries and small island developing States, to increase significantly
-  the availability of high-quality, timely and reliable data disaggregated by income,
-  gender, age, race, ethnicity, migratory status, disability, geographic location
-  and other characteristics relevant in national contexts
+target: global_targets.17-18.title
 target_id: '17.18'
 un_custodian_agency: PARIS21
 un_designated_tier: '1'

--- a/meta/17-19-1.md
+++ b/meta/17-19-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-19-1.title
 graph_type: line
 indicator: 17.19.1
-indicator_name: Dollar value of all resources made available to strengthen statistical
-  capacity in developing countries
+indicator_name: global_indicators.17-19-1.title
 indicator_sort_order: 17-19-01
 layout: indicator
 permalink: /17-19-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: By 2030, build on existing initiatives to develop measurements of progress
-  on sustainable development that complement gross domestic product, and support statistical
-  capacity-building in developing countries
+target: global_targets.17-19.title
 target_id: '17.19'
-graph_title: Dollar value of all resources made available to strengthen statistical capacity
-  in developing countries
 un_custodian_agency: PARIS21
 un_designated_tier: '1'
 ---

--- a/meta/17-19-2.md
+++ b/meta/17-19-2.md
@@ -2,14 +2,10 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-02a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: Proportion of countries that (a) have conducted at least one population
-  and housing census in the last 10 years; and (b) have achieved 100 per cent birth
-  registration and 80 per cent death registration
+graph_title: global_indicators.17-19-2.title
 graph_type: line
 indicator: 17.19.2
-indicator_name: Proportion of countries that (a) have conducted at least one population
-  and housing census in the last 10 years; and (b) have achieved 100 per cent birth
-  registration and 80 per cent death registration
+indicator_name: global_indicators.17-19-2.title
 indicator_sort_order: 17-19-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,9 +15,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, build on existing initiatives to develop measurements of progress
-  on sustainable development that complement gross domestic product, and support statistical
-  capacity-building in developing countries
+target: global_targets.17-19.title
 target_id: '17.19'
 un_custodian_agency: UNSD
 un_designated_tier: '1'

--- a/meta/17-2-1.md
+++ b/meta/17-2-1.md
@@ -2,27 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-2-1.title
 graph_type: line
 indicator: 17.2.1
-indicator_name: "Net official development assistance, total and to least developed\
-  \ countries, as a proportion of the Organization for Economic Cooperation and Development\
-  \ (OECD) Development Assistance Committee donors\u2019 gross national income (GNI)"
+indicator_name: global_indicators.17-2-1.title
 indicator_sort_order: 17-02-01
 layout: indicator
 permalink: /17-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Developed countries to implement fully their official development assistance
-  commitments, including the commitment by many developed countries to achieve the
-  target of 0.7 per cent of gross national income for official development assistance
-  (ODA/GNI) to developing countries and 0.15 to 0.20 per cent of ODA/GNI to least
-  developed countries; ODA providers are encouraged to consider setting a target to
-  provide at least 0.20 per cent of ODA/GNI to least developed countries
+target: global_targets.17-2.title
 target_id: '17.2'
-graph_title: "Net official development assistance, total and to least developed countries,\
-  \ as a proportion of the Organization for Economic Cooperation and Development (OECD)\
-  \ Development Assistance Committee donors\u2019 gross national income (GNI)"
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'
 ---

--- a/meta/17-3-1.md
+++ b/meta/17-3-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-3-1.title
 graph_type: line
 indicator: 17.3.1
-indicator_name: Foreign direct investments (FDI), official development assistance
-  and South-South Cooperation as a proportion of total domestic budget
+indicator_name: global_indicators.17-3-1.title
 indicator_sort_order: 17-03-01
 layout: indicator
 permalink: /17-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Mobilize additional financial resources for developing countries from multiple
-  sources
+target: global_targets.17-3.title
 target_id: '17.3'
-graph_title: Foreign direct investments (FDI), official development assistance and South-South
-  Cooperation as a proportion of total domestic budget
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD),
   United Nations Conference on Trade and Development (UNCTAD)
 un_designated_tier: '1'

--- a/meta/17-3-2.md
+++ b/meta/17-3-2.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: Volume of remittances (in United States dollars) as a proportion of total
-  GDP
+graph_title: global_indicators.17-3-2.title
 graph_type: line
 indicator: 17.3.2
-indicator_name: Volume of remittances (in United States dollars) as a proportion of
-  total GDP
+indicator_name: global_indicators.17-3-2.title
 indicator_sort_order: 17-03-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +16,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat, The Central Bank of RA
-target: Mobilize additional financial resources for developing countries from multiple
-  sources
+target: global_targets.17-3.title
 target_id: '17.3'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/17-4-1.md
+++ b/meta/17-4-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-4-1.title
 graph_type: line
 indicator: 17.4.1
-indicator_name: Debt service as a proportion of exports of goods and services
+indicator_name: global_indicators.17-4-1.title
 indicator_sort_order: 17-04-01
 layout: indicator
 permalink: /17-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Assist developing countries in attaining long-term debt sustainability through
-  coordinated policies aimed at fostering debt financing, debt relief and debt restructuring,
-  as appropriate, and address the external debt of highly indebted poor countries
-  to reduce debt distress
+target: global_targets.17-4.title
 target_id: '17.4'
-graph_title: Debt service as a proportion of exports of goods and services
 un_custodian_agency: World Bank
 un_designated_tier: '1'
 ---

--- a/meta/17-5-1.md
+++ b/meta/17-5-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-5-1.title
 graph_type: line
 indicator: 17.5.1
-indicator_name: Number of countries that adopt and implement investment promotion
-  regimes for least developed countries
+indicator_name: global_indicators.17-5-1.title
 indicator_sort_order: 17-05-01
 layout: indicator
 permalink: /17-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Adopt and implement investment promotion regimes for least developed countries
+target: global_targets.17-5.title
 target_id: '17.5'
-graph_title: Number of countries that adopt and implement investment promotion regimes for
-  least developed countries
 un_custodian_agency: UNCTAD
 un_designated_tier: '3'
 ---

--- a/meta/17-6-1.md
+++ b/meta/17-6-1.md
@@ -2,24 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-6-1.title
 graph_type: line
 indicator: 17.6.1
-indicator_name: Number of science and/or technology cooperation agreements and programmes
-  between countries, by type of cooperation
+indicator_name: global_indicators.17-6-1.title
 indicator_sort_order: 17-06-01
 layout: indicator
 permalink: /17-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance North-South, South-South and triangular regional and international
-  cooperation on and access to science, technology and innovation and enhance knowledge-sharing
-  on mutually agreed terms, including through improved coordination among existing
-  mechanisms, in particular at the United Nations level, and through a global technology
-  facilitation mechanism
+target: global_targets.17-6.title
 target_id: '17.6'
-graph_title: Number of science and/or technology cooperation agreements and programmes between
-  countries, by type of cooperation
 un_custodian_agency: United Nations Education,Scientific and Cultural Organisation
   (UNESCO) - Institute for Statistics (UIS)
 un_designated_tier: '3'

--- a/meta/17-6-2.md
+++ b/meta/17-6-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-06-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
-graph_title: "Fixed Internet broadband subscriptions per 100\_inhabitants, by speed"
+graph_title: global_indicators.17-6-2.title
 graph_type: line
 indicator: 17.6.2
-indicator_name: "Fixed Internet broadband subscriptions per 100\_inhabitants, by speed"
+indicator_name: global_indicators.17-6-2.title
 indicator_sort_order: 17-06-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,11 +17,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat, Commision regulating Public Services of RA
-target: Enhance North-South, South-South and triangular regional and international
-  cooperation on and access to science, technology and innovation and enhance knowledge-sharing
-  on mutually agreed terms, including through improved coordination among existing
-  mechanisms, in particular at the United Nations level, and through a global technology
-  facilitation mechanism
+target: global_targets.17-6.title
 target_id: '17.6'
 un_custodian_agency: International Telecommunication Union (ITU)
 un_designated_tier: '1'

--- a/meta/17-7-1.md
+++ b/meta/17-7-1.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
+graph_title: global_indicators.17-7-1.title
 graph_type: line
 indicator: 17.7.1
-indicator_name: Total amount of approved funding for developing countries to promote
-  the development, transfer, dissemination and diffusion of environmentally sound
-  technologies
+indicator_name: global_indicators.17-7-1.title
 indicator_sort_order: 17-07-01
 layout: indicator
 permalink: /17-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Promote the development, transfer, dissemination and diffusion of environmentally
-  sound technologies to developing countries on favourable terms, including on concessional
-  and preferential terms, as mutually agreed
+target: global_targets.17-7.title
 target_id: '17.7'
-graph_title: Total amount of approved funding for developing countries to promote the development,
-  transfer, dissemination and diffusion of environmentally sound technologies
 un_custodian_agency: UNEP-CTCN
 un_designated_tier: '3'
 ---

--- a/meta/17-8-1.md
+++ b/meta/17-8-1.md
@@ -4,13 +4,13 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-08-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469
   KB)
-graph_title: Proportion of individuals using the Internet
+graph_title: global_indicators.17-8-1.title
 graph_type: line
 indicator: 17.8.1
 indicator_definition: The indicator proportion of individuals using the Internet is
   defined as the proportion of individuals who used the Internet from any location
   in the last three months.
-indicator_name: Proportion of individuals using the Internet
+indicator_name: global_indicators.17-8-1.title
 indicator_sort_order: 17-08-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -20,9 +20,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: Armstat, ILCS
-target: Fully operationalize the technology bank and science, technology and innovation
-  capacity-building mechanism for least developed countries by 2017 and enhance the
-  use of enabling technology, in particular information and communications technology
+target: global_targets.17-8.title
 target_id: '17.8'
 un_custodian_agency: International Telecommunications Union (ITU)
 un_designated_tier: '1'

--- a/meta/17-9-1.md
+++ b/meta/17-9-1.md
@@ -3,25 +3,21 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-09-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 209
   KB)
+graph_title: global_indicators.17-9-1.title
 graph_type: line
 indicator: 17.9.1
 indicator_definition: Total Overseas Development Aid (ODA) and Other Official Flows
   (OOF) to developing countries quantify the public effort (excluding export credits)
   that donors provide to developing countries.
-indicator_name: Dollar value of financial and technical assistance (including through
-  North-South, South-South and triangular cooperation) committed to developing countries
+indicator_name: global_indicators.17-9-1.title
 indicator_sort_order: 17-09-01
 layout: indicator
 permalink: /17-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: Enhance international support for implementing effective and targeted capacity-building
-  in developing countries to support national plans to implement all the Sustainable
-  Development Goals, including through North-South, South-South and triangular cooperation
+target: global_targets.17-9.title
 target_id: '17.9'
-graph_title: Dollar value of financial and technical assistance (including through North-South,
-  South-South and triangular cooperation) committed to developing countries
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
   United Nations Environment (UNEP) World Bank (WB)
 un_designated_tier: '1'

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: Prevalence of undernourishment
+graph_title: global_indicators.2-1-1.title
 graph_type: line
 indicator: 2.1.1
-indicator_name: Prevalence of undernourishment
+indicator_name: global_indicators.2-1-1.title
 indicator_sort_order: 02-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,9 +16,7 @@ reporting_status: complete
 sdg_goal: '2'
 source_active_1: true
 source_organisation_1: Armstat, ILCS
-target: By 2030, end hunger and ensure access by all people, in particular the poor
-  and people in vulnerable situations, including infants, to safe, nutritious and
-  sufficient food all year round.
+target: global_targets.2-1.title
 target_id: '2.1'
 un_custodian_agency: FAO
 un_designated_tier: '1'

--- a/meta/2-1-2.md
+++ b/meta/2-1-2.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 426
   KB)
+graph_title: global_indicators.2-1-2.title
 graph_type: line
 indicator: 2.1.2
-indicator_name: Prevalence of moderate or severe food insecurity in the population,
-  based on the Food Insecurity Experience Scale (FIES)
+indicator_name: global_indicators.2-1-2.title
 indicator_sort_order: 02-01-02
 layout: indicator
 permalink: /2-1-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, end hunger and ensure access by all people, in particular the poor
-  and people in vulnerable situations, including infants, to safe, nutritious and
-  sufficient food all year round.
+target: global_targets.2-1.title
 target_id: '2.1'
-graph_title: Prevalence of moderate or severe food insecurity in the population, based on
-  the Food Insecurity Experience Scale (FIES)
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '1'
 ---

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -3,14 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: Prevalence of stunting (height for age <-2 standard deviation from the
-  median of the World Health Organization (WHO) Child Growth Standards) among children
-  under 5 years of age
+graph_title: global_indicators.2-2-1.title
 graph_type: line
 indicator: 2.2.1
-indicator_name: Prevalence of stunting (height for age <-2 standard deviation from
-  the median of the World Health Organization (WHO) Child Growth Standards) among
-  children under 5 years of age
+indicator_name: global_indicators.2-2-1.title
 indicator_sort_order: 02-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -20,10 +16,7 @@ reporting_status: complete
 sdg_goal: '2'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: By 2030, end all forms of malnutrition, including achieving, by 2025, the
-  internationally agreed targets on stunting and wasting in children under 5 years
-  of age, and address the nutritional needs of adolescent girls, pregnant and lactating
-  women and older persons
+target: global_targets.2-2.title
 target_id: '2.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '1'

--- a/meta/2-2-2.md
+++ b/meta/2-2-2.md
@@ -3,14 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-02a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: Prevalence of malnutrition (weight for height >+2 or <-2 standard deviation
-  from the median of the WHO Child Growth Standards) among children under 5 years
-  of age, by type (wasting and overweight)
+graph_title: global_indicators.2-2-2.title
 graph_type: line
 indicator: 2.2.2
-indicator_name: Prevalence of malnutrition (weight for height >+2 or <-2 standard
-  deviation from the median of the WHO Child Growth Standards) among children under
-  5 years of age, by type (wasting and overweight)
+indicator_name: global_indicators.2-2-2.title
 indicator_sort_order: 02-02-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -20,10 +16,7 @@ reporting_status: complete
 sdg_goal: '2'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: By 2030, end all forms of malnutrition, including achieving, by 2025, the
-  internationally agreed targets on stunting and wasting in children under 5 years
-  of age, and address the nutritional needs of adolescent girls, pregnant and lactating
-  women and older persons
+target: global_targets.2-2.title
 target_id: '2.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '1'

--- a/meta/2-3-1.md
+++ b/meta/2-3-1.md
@@ -3,24 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-2.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.2-3-1.title
 graph_type: line
 indicator: 2.3.1
-indicator_name: Volume of production per labour unit by classes of farming/pastoral/forestry
-  enterprise size
+indicator_name: global_indicators.2-3-1.title
 indicator_sort_order: 02-03-01
 layout: indicator
 permalink: /2-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, double the agricultural productivity and incomes of small-scale food
-  producers, in particular women, indigenous peoples, family farmers, pastoralists
-  and fishers, including through secure and equal access to land, other productive
-  resources and inputs, knowledge, financial services, markets and opportunities for
-  value addition and non-farm employment
+target: global_targets.2-3.title
 target_id: '2.3'
-graph_title: Volume of production per labour unit by classes of farming/pastoral/forestry
-  enterprise size
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '3'
 ---

--- a/meta/2-3-2.md
+++ b/meta/2-3-2.md
@@ -3,23 +3,18 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-2.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.2-3-2.title
 graph_type: line
 indicator: 2.3.2
-indicator_name: Average income of small-scale food producers, by sex and indigenous
-  status
+indicator_name: global_indicators.2-3-2.title
 indicator_sort_order: 02-03-02
 layout: indicator
 permalink: /2-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2030, double the agricultural productivity and incomes of small-scale food
-  producers, in particular women, indigenous peoples, family farmers, pastoralists
-  and fishers, including through secure and equal access to land, other productive
-  resources and inputs, knowledge, financial services, markets and opportunities for
-  value addition and non-farm employment
+target: global_targets.2-3.title
 target_id: '2.3'
-graph_title: Average income of small-scale food producers, by sex and indigenous status
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '3'
 ---

--- a/meta/2-4-1.md
+++ b/meta/2-4-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: Proportion of agricultural area under productive and sustainable agriculture
+graph_title: global_indicators.2-4-1.title
 graph_type: line
 indicator: 2.4.1
-indicator_name: Proportion of agricultural area under productive and sustainable agriculture
+indicator_name: global_indicators.2-4-1.title
 indicator_sort_order: 02-04-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,11 +16,7 @@ reporting_status: complete
 sdg_goal: '2'
 source_active_1: true
 source_organisation_1: Ministry of Agriculture of RA
-target: By 2030, ensure sustainable food production systems and implement resilient
-  agricultural practices that increase productivity and production, that help maintain
-  ecosystems, that strengthen capacity for adaptation to climate change, extreme weather,
-  drought, flooding and other disasters and that progressively improve land and soil
-  quality
+target: global_targets.2-4.title
 target_id: '2.4'
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '3'

--- a/meta/2-5-1.md
+++ b/meta/2-5-1.md
@@ -3,25 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 334
   KB)
+graph_title: global_indicators.2-5-1.title
 graph_type: line
 indicator: 2.5.1
-indicator_name: Number of plant and animal genetic resources for food and agriculture
-  secured in either medium or long-term conservation facilities
+indicator_name: global_indicators.2-5-1.title
 indicator_sort_order: 02-05-01
 layout: indicator
 permalink: /2-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed
-  and domesticated animals and their related wild species, including through soundly
-  managed and diversified seed and plant banks at the national, regional and international
-  levels, and promote access to and fair and equitable sharing of benefits arising
-  from the utilization of genetic resources and associated traditional knowledge,
-  as internationally agreed
+target: global_targets.2-5.title
 target_id: '2.5'
-graph_title: Number of plant and animal genetic resources for food and agriculture secured
-  in either medium or long-term conservation facilities
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '1'
 ---

--- a/meta/2-5-2.md
+++ b/meta/2-5-2.md
@@ -3,27 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 220
   KB)
+graph_title: global_indicators.2-5-2.title
 graph_type: line
 indicator: 2.5.2
 indicator_definition: Proportion of local breeds classified as being at risk, not-at-risk
   or at unknown level of risk extinction
-indicator_name: Proportion of local breeds classified as being at risk, not-at-risk
-  or at unknown level of risk of extinction
+indicator_name: global_indicators.2-5-2.title
 indicator_sort_order: 02-05-02
 layout: indicator
 permalink: /2-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed
-  and domesticated animals and their related wild species, including through soundly
-  managed and diversified seed and plant banks at the national, regional and international
-  levels, and promote access to and fair and equitable sharing of benefits arising
-  from the utilization of genetic resources and associated traditional knowledge,
-  as internationally agreed
+target: global_targets.2-5.title
 target_id: '2.5'
-graph_title: Proportion of local breeds classified as being at risk, not-at-risk or at unknown
-  level of risk of extinction
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '1'
 ---

--- a/meta/2-a-1.md
+++ b/meta/2-a-1.md
@@ -3,27 +3,23 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 223
   KB)
+graph_title: global_indicators.2-a-1.title
 graph_type: line
 indicator: 2.a.1
-indicator_definition: "An Agriculture Orientation Index (AOI) greater than 1 reflects\
-  \ a higher orientation towards the agriculture sector, which receives a higher share\
-  \ of government spending relative to its contribution to economic value-added. An\
-  \ AOI less than 1 reflects a lower orientation to agriculture, while an AOI equal\
-  \ to 1 reflects neutrality in a government\u2019s orientation to the agriculture\
-  \ sector."
-indicator_name: The agriculture orientation index for government expenditures
+indicator_definition: An Agriculture Orientation Index (AOI) greater than 1 reflects
+  a higher orientation towards the agriculture sector, which receives a higher share
+  of government spending relative to its contribution to economic value-added. An
+  AOI less than 1 reflects a lower orientation to agriculture, while an AOI equal
+  to 1 reflects neutrality in a government’s orientation to the agriculture sector.
+indicator_name: global_indicators.2-a-1.title
 indicator_sort_order: 02-aa-01
 layout: indicator
 permalink: /2-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Increase investment, including through enhanced international cooperation,
-  in rural infrastructure, agricultural research and extension services, technology
-  development and plant and livestock gene banks in order to enhance agricultural
-  productive capacity in developing countries, in particular least developed countries
+target: global_targets.2-a.title
 target_id: 2.a
-graph_title: The agriculture orientation index for government expenditures
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '2'
 ---

--- a/meta/2-a-2.md
+++ b/meta/2-a-2.md
@@ -3,25 +3,20 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
+graph_title: global_indicators.2-a-2.title
 graph_type: line
 indicator: 2.a.2
 indicator_definition: Gross disbursements of total ODA and other official flows from
   all donors to the agriculture sector.
-indicator_name: Total official flows (official development assistance plus other official
-  flows) to the agriculture sector
+indicator_name: global_indicators.2-a-2.title
 indicator_sort_order: 02-aa-02
 layout: indicator
 permalink: /2-a-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Increase investment, including through enhanced international cooperation,
-  in rural infrastructure, agricultural research and extension services, technology
-  development and plant and livestock gene banks in order to enhance agricultural
-  productive capacity in developing countries, in particular least developed countries
+target: global_targets.2-a.title
 target_id: 2.a
-graph_title: Total official flows (official development assistance plus other official flows)
-  to the agriculture sector
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'
 ---

--- a/meta/2-b-1.md
+++ b/meta/2-b-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
+graph_title: global_indicators.2-b-1.title
 graph_type: line
 indicator: 2.b.1
-indicator_name: Agricultural export subsidies
+indicator_name: global_indicators.2-b-1.title
 indicator_sort_order: 02-bb-01
 layout: indicator
 permalink: /2-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Correct and prevent trade restrictions and distortions in world agricultural
-  markets, including through the parallel elimination of all forms of agricultural
-  export subsidies and all export measures with equivalent effect, in accordance with
-  the mandate of the Doha Development Round
+target: global_targets.2-b.title
 target_id: 2.b
-graph_title: Agricultural export subsidies
 un_custodian_agency: WTO
 un_designated_tier: '1'
 ---

--- a/meta/2-c-1.md
+++ b/meta/2-c-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
+graph_title: global_indicators.2-c-1.title
 graph_type: line
 indicator: 2.c.1
-indicator_name: Indicator of food price anomalies
+indicator_name: global_indicators.2-c-1.title
 indicator_sort_order: 02-cc-01
 layout: indicator
 permalink: /2-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: Adopt measures to ensure the proper functioning of food commodity markets
-  and their derivatives and facilitate timely access to market information, including
-  on food reserves, in order to help limit extreme food price volatility
+target: global_targets.2-c.title
 target_id: 2.c
-graph_title: Indicator of food price anomalies
 un_custodian_agency: FAO
 un_designated_tier: '2'
 ---

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -3,10 +3,10 @@ computation_units: per 100,000 live births
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: Maternal mortality ratio
+graph_title: global_indicators.3-1-1.title
 graph_type: line
 indicator: 3.1.1
-indicator_name: Maternal mortality ratio
+indicator_name: global_indicators.3-1-1.title
 indicator_sort_order: 03-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,8 +16,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, reduce the global maternal mortality ratio to less than 70 per 100,000
-  live births
+target: global_targets.3-1.title
 target_id: '3.1'
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/3-1-2.md
+++ b/meta/3-1-2.md
@@ -4,11 +4,11 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 374
   KB)
-graph_title: Proportion of births attended by skilled health personnel
+graph_title: global_indicators.3-1-2.title
 graph_type: line
 indicator: 3.1.2
 indicator_definition: Percentage of births attended by skilled health personnel
-indicator_name: Proportion of births attended by skilled health personnel
+indicator_name: global_indicators.3-1-2.title
 indicator_sort_order: 03-01-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +18,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: By 2030, reduce the global maternal mortality ratio to less than 70 per 100,000
-  live births
+target: global_targets.3-1.title
 target_id: '3.1'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '1'

--- a/meta/3-2-1.md
+++ b/meta/3-2-1.md
@@ -4,7 +4,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 225
   KB)
-graph_title: Under-five mortality rate
+graph_title: global_indicators.3-2-1.title
 graph_type: line
 indicator: 3.2.1
 indicator_definition: The probability of a child born in a specific year or period
@@ -13,7 +13,7 @@ indicator_definition: The probability of a child born in a specific year or peri
   defined here is, strictly speaking, not a rate (i.e. the number of deaths divided
   by the number of population at risk during a certain period of time) but a probability
   of death derived from a life table and expressed as a rate per 1000 live births.
-indicator_name: Under-five mortality rate
+indicator_name: global_indicators.3-2-1.title
 indicator_sort_order: 03-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -23,10 +23,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, end preventable deaths of newborns and children under 5 years of
-  age, with all countries aiming to reduce neonatal mortality to at least as low as
-  12 per 1,000 live births and under-5 mortality to at least as low as 25 per 1,000
-  live births
+target: global_targets.3-2.title
 target_id: '3.2'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '1'

--- a/meta/3-2-2.md
+++ b/meta/3-2-2.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 225
   KB)
-graph_title: Neonatal mortality rate
+graph_title: global_indicators.3-2-2.title
 graph_type: line
 indicator: 3.2.2
 indicator_definition: Probability that a child born in a specific year or period will
@@ -12,7 +12,7 @@ indicator_definition: Probability that a child born in a specific year or period
   live births during the first 28 completed days of life) may be subdivided into early
   neonatal deaths, occurring during the first 7 days of life, and late neonatal deaths,
   occurring after the 7th day but before the 28th completed day of life.
-indicator_name: Neonatal mortality rate
+indicator_name: global_indicators.3-2-2.title
 indicator_sort_order: 03-02-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -20,10 +20,7 @@ permalink: /3-2-2/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: By 2030, end preventable deaths of newborns and children under 5 years of
-  age, with all countries aiming to reduce neonatal mortality to at least as low as
-  12 per 1,000 live births and under-5 mortality to at least as low as 25 per 1,000
-  live births
+target: global_targets.3-2.title
 target_id: '3.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '1'

--- a/meta/3-3-1.md
+++ b/meta/3-3-1.md
@@ -4,14 +4,12 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 372
   KB)
-graph_title: Number of new HIV infections per 1,000 uninfected population, by sex,
-  age and key populations
+graph_title: global_indicators.3-3-1.title
 graph_type: line
 indicator: 3.3.1
 indicator_definition: Number of new HIV infections per 1,000 uninfected population,
   by sex, age and key populations
-indicator_name: Number of new HIV infections per 1,000 uninfected population, by sex,
-  age and key populations
+indicator_name: global_indicators.3-3-1.title
 indicator_sort_order: 03-03-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -21,8 +19,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Ministry of Health of RA
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target: global_targets.3-3.title
 target_id: '3.3'
 un_custodian_agency: The Joint United Nations Programme on HIV/AIDS (UNAIDS)
 un_designated_tier: '2'

--- a/meta/3-3-2.md
+++ b/meta/3-3-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 61
   KB)
-graph_title: Tuberculosis incidence
+graph_title: global_indicators.3-3-2.title
 graph_type: line
 indicator: 3.3.2
-indicator_name: Tuberculosis incidence
+indicator_name: global_indicators.3-3-2.title
 indicator_sort_order: 03-03-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,8 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Health of RA
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target: global_targets.3-3.title
 target_id: '3.3'
 un_custodian_agency: World Health Organization (WHO)
 un_designated_tier: '1'

--- a/meta/3-3-3.md
+++ b/meta/3-3-3.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 431
   KB)
-graph_title: Malaria incidence per 1,000 population
+graph_title: global_indicators.3-3-3.title
 graph_type: line
 indicator: 3.3.3
-indicator_name: Malaria incidence per 1,000 population
+indicator_name: global_indicators.3-3-3.title
 indicator_sort_order: 03-03-03
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Health of RA
-target: 3.3 By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected
-  tropical diseases and combat hepatitis, water-borne diseases and other communicable
-  diseases
+target: global_targets.3-3.title
 target_id: '3.3'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: 1

--- a/meta/3-3-4.md
+++ b/meta/3-3-4.md
@@ -3,10 +3,10 @@ computation_units: per 100,000 population
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: Hepatitis B incidence per 100,000 population
+graph_title: global_indicators.3-3-4.title
 graph_type: line
 indicator: 3.3.4
-indicator_name: Hepatitis B incidence per 100,000 population
+indicator_name: global_indicators.3-3-4.title
 indicator_sort_order: 03-03-04
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,8 +16,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Health of RA
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target: global_targets.3-3.title
 target_id: '3.3'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '2'

--- a/meta/3-3-5.md
+++ b/meta/3-3-5.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-05.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
+graph_title: global_indicators.3-3-5.title
 graph_type: line
 indicator: 3.3.5
-indicator_name: Number of people requiring interventions against neglected tropical
-  diseases
+indicator_name: global_indicators.3-3-5.title
 indicator_sort_order: 03-03-05
 layout: indicator
 permalink: /3-3-5/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, end the epidemics of AIDS, tuberculosis, malaria and neglected tropical
-  diseases and combat hepatitis, water-borne diseases and other communicable diseases
+target: global_targets.3-3.title
 target_id: '3.3'
-graph_title: Number of people requiring interventions against neglected tropical diseases
 un_custodian_agency: WHO
 un_designated_tier: '1'
 ---

--- a/meta/3-4-1.md
+++ b/meta/3-4-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 72.6
   KB)
-graph_title: Mortality rate attributed to cardiovascular
+graph_title: global_indicators.3-4-1.title
 graph_type: line
 indicator: 3.4.1
 indicator_definition: Probability of dying between the ages of 30 and 70 years from
@@ -12,7 +12,7 @@ indicator_definition: Probability of dying between the ages of 30 and 70 years f
   cardiovascular disease, cancer, diabetes, or chronic respiratory disease, assuming
   that s/he would experience current mortality rates at every age and s/he would not
   die from any other cause of death.
-indicator_name: Mortality rate attributed to cardiovascular
+indicator_name: global_indicators.3-4-1.title
 indicator_sort_order: 03-04-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -20,8 +20,7 @@ permalink: /3-4-1/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: By 2030, reduce by one third premature mortality from non-communicable diseases
-  through prevention and treatment and promote mental health and well-being
+target: global_targets.3-4.title
 target_id: '3.4'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-4-2.md
+++ b/meta/3-4-2.md
@@ -4,11 +4,11 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 65.1
   KB)
-graph_title: Suicide mortality rate
+graph_title: global_indicators.3-4-2.title
 graph_type: line
 indicator: 3.4.2
 indicator_definition: Suicide mortality rates
-indicator_name: Suicide mortality rate
+indicator_name: global_indicators.3-4-2.title
 indicator_sort_order: 03-04-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +18,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, reduce by one third premature mortality from non-communicable diseases
-  through prevention and treatment and promote mental health and well-being
+target: global_targets.3-4.title
 target_id: '3.4'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-5-1.md
+++ b/meta/3-5-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
+graph_title: global_indicators.3-5-1.title
 graph_type: line
 indicator: 3.5.1
-indicator_name: Coverage of treatment interventions (pharmacological, psychosocial
-  and rehabilitation and aftercare services) for substance use disorders
+indicator_name: global_indicators.3-5-1.title
 indicator_sort_order: 03-05-01
 layout: indicator
 permalink: /3-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Strengthen the prevention and treatment of substance abuse, including narcotic
-  drug abuse and harmful use of alcohol
+target: global_targets.3-5.title
 target_id: '3.5'
-graph_title: Coverage of treatment interventions (pharmacological, psychosocial and rehabilitation
-  and aftercare services) for substance use disorders
 un_custodian_agency: WHO,UNODC
 un_designated_tier: '3'
 ---

--- a/meta/3-5-2.md
+++ b/meta/3-5-2.md
@@ -4,14 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214
   KB)
-graph_title: Harmful use of alcohol, defined according to the national context as
-  alcohol per capita consumption (aged 15 years and older) within a calendar year
-  in litres of pure alcohol
+graph_title: global_indicators.3-5-2.title
 graph_type: line
 indicator: 3.5.2
-indicator_name: Harmful use of alcohol, defined according to the national context
-  as alcohol per capita consumption (aged 15 years and older) within a calendar year
-  in litres of pure alcohol
+indicator_name: global_indicators.3-5-2.title
 indicator_sort_order: 03-05-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -21,8 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Health of RA
-target: Strengthen the prevention and treatment of substance abuse, including narcotic
-  drug abuse and harmful use of alcohol
+target: global_targets.3-5.title
 target_id: '3.5'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-6-1.md
+++ b/meta/3-6-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213
   KB)
-graph_title: Death rate due to road traffic injuries
+graph_title: global_indicators.3-6-1.title
 graph_type: line
 indicator: 3.6.1
-indicator_name: Death rate due to road traffic injuries
+indicator_name: global_indicators.3-6-1.title
 indicator_sort_order: 03-06-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,8 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2020, halve the number of global deaths and injuries from road traffic
-  accidents
+target: global_targets.3-6.title
 target_id: '3.6'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-07-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: Proportion of women of reproductive age (aged 15-49 years) who have their
-  need for family planning satisfied with modern methods
+graph_title: global_indicators.3-7-1.title
 graph_type: line
 indicator: 3.7.1
-indicator_name: Proportion of women of reproductive age (aged 15-49 years) who have
-  their need for family planning satisfied with modern methods
+indicator_name: global_indicators.3-7-1.title
 indicator_sort_order: 03-07-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,9 +16,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: By 2030, ensure universal access to sexual and reproductive health-care services,
-  including for family planning, information and education, and the integration of
-  reproductive health into national strategies and programmes
+target: global_targets.3-7.title
 target_id: '3.7'
 un_custodian_agency: DESA Population Division
 un_designated_tier: '1'

--- a/meta/3-7-2.md
+++ b/meta/3-7-2.md
@@ -3,14 +3,12 @@ data_non_statistical: false
 goal_meta_link: http://data.un.org/Data.aspx?q=births&d=WDI&f=Indicator_Code%3aSP.ADO.TFRT
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 90.8
   KB)
-graph_title: Adolescent birth rate (aged 10-14 years; aged 15-19 years) per 1,000
-  women in that age group
+graph_title: global_indicators.3-7-2.title
 graph_type: line
 indicator: 3.7.2
 indicator_definition: Adolescent birth rate (aged 10-14 years; aged 15-19 years) per
   1,000 women in that age group
-indicator_name: Adolescent birth rate (aged 10-14 years; aged 15-19 years) per 1,000
-  women in that age group
+indicator_name: global_indicators.3-7-2.title
 indicator_sort_order: 03-07-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,9 +16,7 @@ permalink: /3-7-2/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: By 2030, ensure universal access to sexual and reproductive health-care services,
-  including for family planning, information and education, and the integration of
-  reproductive health into national strategies and programmes
+target: global_targets.3-7.title
 target_id: '3.7'
 un_custodian_agency: Department of Economic and Social Affairs (DESA) Population Division
   United Nations Population Fund (UNFPA )

--- a/meta/3-8-1.md
+++ b/meta/3-8-1.md
@@ -2,26 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
+graph_title: global_indicators.3-8-1.title
 graph_type: line
 indicator: 3.8.1
-indicator_name: Coverage of essential health services (defined as the average coverage
-  of essential services based on tracer interventions that include reproductive, maternal,
-  newborn and child health, infectious diseases, non-communicable diseases and service
-  capacity and access, among the general and the most disadvantaged population)
+indicator_name: global_indicators.3-8-1.title
 indicator_sort_order: 03-08-01
 layout: indicator
 permalink: /3-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Achieve universal health coverage, including financial risk protection, access
-  to quality essential health-care services and access to safe, effective, quality
-  and affordable essential medicines and vaccines for all
+target: global_targets.3-8.title
 target_id: '3.8'
-graph_title: Coverage of essential health services (defined as the average coverage of essential
-  services based on tracer interventions that include reproductive, maternal, newborn
-  and child health, infectious diseases, non-communicable diseases and service capacity
-  and access, among the general and the most disadvantaged population)
 un_custodian_agency: WHO
 un_designated_tier: '3'
 ---

--- a/meta/3-8-2.md
+++ b/meta/3-8-2.md
@@ -4,12 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: Proportion of population with large household expenditures on health
-  as a share of total household expenditure or income
+graph_title: global_indicators.3-8-2.title
 graph_type: line
 indicator: 3.8.2
-indicator_name: Proportion of population with large household expenditures on health
-  as a share of total household expenditure or income
+indicator_name: global_indicators.3-8-2.title
 indicator_sort_order: 03-08-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,9 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat
-target: Achieve universal health coverage, including financial risk protection, access
-  to quality essential health-care services and access to safe, effective, quality
-  and affordable essential medicines and vaccines for all
+target: global_targets.3-8.title
 target_id: '3.8'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '2'

--- a/meta/3-9-1.md
+++ b/meta/3-9-1.md
@@ -3,19 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 216
   KB)
+graph_title: global_indicators.3-9-1.title
 graph_type: line
 indicator: 3.9.1
-indicator_name: Mortality rate attributed to household and ambient air pollution
+indicator_name: global_indicators.3-9-1.title
 indicator_sort_order: 03-09-01
 layout: indicator
 permalink: /3-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: By 2030, substantially reduce the number of deaths and illnesses from hazardous
-  chemicals and air, water and soil pollution and contamination
+target: global_targets.3-9.title
 target_id: '3.9'
-graph_title: Mortality rate attributed to household and ambient air pollution
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'
 ---

--- a/meta/3-9-2.md
+++ b/meta/3-9-2.md
@@ -3,8 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214
   KB)
-graph_title: Mortality rate attributed to unsafe water, unsafe sanitation and lack
-  of hygiene (exposure to unsafe Water, Sanitation and Hygiene for All (WASH) services)
+graph_title: global_indicators.3-9-2.title
 graph_type: line
 indicator: 3.9.2
 indicator_definition: The mortality rate attributed to unsafe water, unsafe sanitation
@@ -12,8 +11,7 @@ indicator_definition: The mortality rate attributed to unsafe water, unsafe sani
   services) as defined as the number of deaths from unsafe water, unsafe sanitation
   and lack of hygiene (exposure to unsafe WASH services) in a year, divided by the
   population, and multiplied by 1,000,000.
-indicator_name: Mortality rate attributed to unsafe water, unsafe sanitation and lack
-  of hygiene (exposure to unsafe Water, Sanitation and Hygiene for All (WASH) services)
+indicator_name: global_indicators.3-9-2.title
 indicator_sort_order: 03-09-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -21,8 +19,7 @@ permalink: /3-9-2/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: By 2030, substantially reduce the number of deaths and illnesses from hazardous
-  chemicals and air, water and soil pollution and contamination
+target: global_targets.3-9.title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-9-3.md
+++ b/meta/3-9-3.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213
   KB)
-graph_title: Mortality rate attributed to unintentional poisoning
+graph_title: global_indicators.3-9-3.title
 graph_type: line
 indicator: 3.9.3
-indicator_name: Mortality rate attributed to unintentional poisoning
+indicator_name: global_indicators.3-9-3.title
 indicator_sort_order: 03-09-03
 layout: indicator
 national_geographical_coverage: Armenia
@@ -15,8 +15,7 @@ permalink: /3-9-3/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: By 2030, substantially reduce the number of deaths and illnesses from hazardous
-  chemicals and air, water and soil pollution and contamination
+target: global_targets.3-9.title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-a-1.md
+++ b/meta/3-a-1.md
@@ -4,12 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 866
   KB)
-graph_title: Age-standardized prevalence of current tobacco use among persons aged
-  15 years and older
+graph_title: global_indicators.3-a-1.title
 graph_type: line
 indicator: 3.a.1
-indicator_name: Age-standardized prevalence of current tobacco use among persons aged
-  15 years and older
+indicator_name: global_indicators.3-a-1.title
 indicator_sort_order: 03-aa-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,8 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Ministry of Health of RA
-target: 3.a Strengthen the implementation of the World Health Organization Framework
-  Convention on Tobacco Control in all countries, as appropriate
+target: global_targets.3-a.title
 target_id: 3.a
 un_custodian_agency: World Health Organization (WHO), Framework Convention on Tobacco
   Control (FCTC)

--- a/meta/3-b-1.md
+++ b/meta/3-b-1.md
@@ -4,12 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: Proportion of the target population covered by all vaccines included
-  in their national programme
+graph_title: global_indicators.3-b-1.title
 graph_type: line
 indicator: 3.b.1
-indicator_name: Proportion of the target population covered by all vaccines included
-  in their national programme
+indicator_name: global_indicators.3-b-1.title
 indicator_sort_order: 03-bb-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,13 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: Support the research and development of vaccines and medicines for the communicable
-  and non-communicable diseases that primarily affect developing countries, provide
-  access to affordable essential medicines and vaccines, in accordance with the Doha
-  Declaration on the TRIPS Agreement and Public Health, which affirms the right of
-  developing countries to use to the full the provisions in the Agreement on Trade-Related
-  Aspects of Intellectual Property Rights regarding flexibilities to protect public
-  health, and, in particular, provide access to medicines for all
+target: global_targets.3-b.title
 target_id: 3.b
 un_custodian_agency: World Health Organization (WHO)  United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/3-b-2.md
+++ b/meta/3-b-2.md
@@ -3,29 +3,21 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0B-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
+graph_title: global_indicators.3-b-2.title
 graph_type: line
 indicator: 3.b.2
 indicator_definition: Total ODA flows to developing countries quantify the public
   effort that donors provide to developing countries for medical research and basic
   health.
-indicator_name: Total net official development assistance to medical research and
-  basic health sectors
+indicator_name: global_indicators.3-b-2.title
 indicator_sort_order: 03-bb-02
 layout: indicator
 permalink: /3-b-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: Support the research and development of vaccines and medicines for the communicable
-  and non-communicable diseases that primarily affect developing countries, provide
-  access to affordable essential medicines and vaccines, in accordance with the Doha
-  Declaration on the TRIPS Agreement and Public Health, which affirms the right of
-  developing countries to use to the full the provisions in the Agreement on Trade-Related
-  Aspects of Intellectual Property Rights regarding flexibilities to protect public
-  health, and, in particular, provide access to medicines for all
+target: global_targets.3-b.title
 target_id: 3.b
-graph_title: Total net official development assistance to medical research and basic health
-  sectors
 un_custodian_agency: Organisation for Economic Co-operation (OECD)
 un_designated_tier: '1'
 ---

--- a/meta/3-b-3.md
+++ b/meta/3-b-3.md
@@ -1,27 +1,18 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
+graph_title: global_indicators.3-b-3.title
 graph_type: line
 indicator: 3.b.3
-indicator_name: Proportion of health facilities that have a core set of relevant essential
-  medicines available and affordable on a sustainable basis
+indicator_name: global_indicators.3-b-3.title
 indicator_sort_order: 03-bb-03
 layout: indicator
 permalink: /3-b-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: "Support the research and development of vaccines and medicines for the communicable\
-  \ and non\u2011communicable diseases that primarily affect developing countries,\
-  \ provide access to affordable essential medicines and vaccines, in accordance with\
-  \ the Doha Declaration on the TRIPS Agreement and Public Health, which affirms the\
-  \ right of developing countries to use to the full the provisions in the Agreement\
-  \ on Trade-Related Aspects of Intellectual Property Rights regarding flexibilities\
-  \ to protect public health, and, in particular, provide access to medicines for\
-  \ all"
+target: global_targets.3-b.title
 target_id: 3.b
-graph_title: Proportion of health facilities that have a core set of relevant essential
-  medicines available and affordable on a sustainable basis
 un_custodian_agency: WHO
 un_designated_tier: '3'
 ---

--- a/meta/3-c-1.md
+++ b/meta/3-c-1.md
@@ -3,12 +3,12 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 207
   KB)
-graph_title: Health worker density and distribution
+graph_title: global_indicators.3-c-1.title
 graph_type: line
 indicator: 3.c.1
 indicator_definition: Density of physicians, nursing and midwifery personnel, dentistry
   personnel, and pharmaceutical personnel per 1,000 persons
-indicator_name: Health worker density and distribution
+indicator_name: global_indicators.3-c-1.title
 indicator_sort_order: 03-cc-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,9 +16,7 @@ permalink: /3-c-1/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: Substantially increase health financing and the recruitment, development,
-  training and retention of the health workforce in developing countries, especially
-  in least developed countries and small island developing States
+target: global_targets.3-c.title
 target_id: 3.c
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-d-1.md
+++ b/meta/3-d-1.md
@@ -3,12 +3,10 @@ computation_units: units
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0D-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: International Health Regulations (IHR) capacity and health emergency
-  preparedness
+graph_title: global_indicators.3-d-1.title
 graph_type: line
 indicator: 3.d.1
-indicator_name: International Health Regulations (IHR) capacity and health emergency
-  preparedness
+indicator_name: global_indicators.3-d-1.title
 indicator_sort_order: 03-dd-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +16,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: Minisrtry of Health of RA
-target: Strengthen the capacity of all countries, in particular developing countries,
-  for early warning, risk reduction and management of national and global health risks
+target: global_targets.3-d.title
 target_id: 3.d
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/4-1-1.md
+++ b/meta/4-1-1.md
@@ -3,23 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.4-1-1.title
 graph_type: line
 indicator: 4.1.1
-indicator_name: 'Proportion of children and young people: (a) in grades 2/3; (b) at
-  the end of primary; and (c) at the end of lower secondary achieving at least a minimum
-  proficiency level in (i) reading and (ii) mathematics, by sex'
+indicator_name: global_indicators.4-1-1.title
 indicator_sort_order: 04-01-01
 layout: indicator
 permalink: /4-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all girls and boys complete free, equitable and quality
-  primary and secondary education leading to relevant and effective learning outcomes
+target: global_targets.4-1.title
 target_id: '4.1'
-graph_title: 'Proportion of children and young people: (a) in grades 2/3; (b) at the end
-  of primary; and (c) at the end of lower secondary achieving at least a minimum proficiency
-  level in (i) reading and (ii) mathematics, by sex'
 un_custodian_agency: UNESCO Institute for Statistics
 un_designated_tier: 3 (a) /2 (b,c)
 ---

--- a/meta/4-2-1.md
+++ b/meta/4-2-1.md
@@ -3,21 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.4-2-1.title
 graph_type: line
 indicator: 4.2.1
-indicator_name: Proportion of children under 5 years of age who are developmentally
-  on track in health, learning and psychosocial well-being, by sex
+indicator_name: global_indicators.4-2-1.title
 indicator_sort_order: 04-02-01
 layout: indicator
 permalink: /4-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all girls and boys have access to quality early childhood
-  development, care and pre-primary education so that they are ready for primary education
+target: global_targets.4-2.title
 target_id: '4.2'
-graph_title: Proportion of children under 5 years of age who are developmentally on track
-  in health, learning and psychosocial well-being, by sex
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '3'
 ---

--- a/meta/4-2-2.md
+++ b/meta/4-2-2.md
@@ -3,21 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 223
   KB)
+graph_title: global_indicators.4-2-2.title
 graph_type: line
 indicator: 4.2.2
-indicator_name: Participation rate in organized learning (one year before the official
-  primary entry age), by sex
+indicator_name: global_indicators.4-2-2.title
 indicator_sort_order: 04-02-02
 layout: indicator
 permalink: /4-2-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all girls and boys have access to quality early childhood
-  development, care and pre-primary education so that they are ready for primary education
+target: global_targets.4-2.title
 target_id: '4.2'
-graph_title: Participation rate in organized learning (one year before the official primary
-  entry age), by sex
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)
 un_designated_tier: '1'

--- a/meta/4-3-1.md
+++ b/meta/4-3-1.md
@@ -3,24 +3,21 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
+graph_title: global_indicators.4-3-1.title
 graph_type: line
 indicator: 4.3.1
 indicator_definition: The percentage of youth and adults in a given age range (e.g.
   15-24 years, 25-64 years, etc.) participating in formal or non-formal education
   or training in a given time period (e.g. last 12 months).
-indicator_name: Participation rate of youth and adults in formal and non-formal education
-  and training in the previous 12 months, by sex
+indicator_name: global_indicators.4-3-1.title
 indicator_sort_order: 04-03-01
 layout: indicator
 permalink: /4-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure equal access for all women and men to affordable and quality
-  technical, vocational and tertiary education, including university
+target: global_targets.4-3.title
 target_id: '4.3'
-graph_title: Participation rate of youth and adults in formal and non-formal education and
-  training in the previous 12 months, by sex
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)
 un_designated_tier: '2'

--- a/meta/4-4-1.md
+++ b/meta/4-4-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214
   KB)
+graph_title: global_indicators.4-4-1.title
 graph_type: line
 indicator: 4.4.1
-indicator_name: Proportion of youth and adults with information and communications
-  technology (ICT) skills, by type of skill
+indicator_name: global_indicators.4-4-1.title
 indicator_sort_order: 04-04-01
 layout: indicator
 permalink: /4-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, substantially increase the number of youth and adults who have relevant
-  skills, including technical and vocational skills, for employment, decent jobs and
-  entrepreneurship
+target: global_targets.4-4.title
 target_id: '4.4'
-graph_title: Proportion of youth and adults with information and communications technology
-  (ICT) skills, by type of skill
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)
 un_designated_tier: '2'

--- a/meta/4-5-1.md
+++ b/meta/4-5-1.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
+graph_title: global_indicators.4-5-1.title
 graph_type: line
 indicator: 4.5.1
-indicator_name: Parity indices (female/male, rural/urban, bottom/top wealth quintile
-  and others such as disability status, indigenous peoples and conflict-affected,
-  as data become available) for all education indicators on this list that can be
-  disaggregated
+indicator_name: global_indicators.4-5-1.title
 indicator_sort_order: 04-05-01
 layout: indicator
 permalink: /4-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, eliminate gender disparities in education and ensure equal access
-  to all levels of education and vocational training for the vulnerable, including
-  persons with disabilities, indigenous peoples and children in vulnerable situations
+target: global_targets.4-5.title
 target_id: '4.5'
-graph_title: Parity indices (female/male, rural/urban, bottom/top wealth quintile and others
-  such as disability status, indigenous peoples and conflict-affected, as data become
-  available) for all education indicators on this list that can be disaggregated
 un_custodian_agency: United Nations Educational, Scientific and Cultural Organization
   (UNESCO)
 un_designated_tier: 1/2/3

--- a/meta/4-6-1.md
+++ b/meta/4-6-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 57.8
   KB)
+graph_title: global_indicators.4-6-1.title
 graph_type: line
 indicator: 4.6.1
-indicator_name: Proportion of population in a given age group achieving at least a
-  fixed level of proficiency in functional (a) literacy and (b) numeracy skills, by
-  sex
+indicator_name: global_indicators.4-6-1.title
 indicator_sort_order: 04-06-01
 layout: indicator
 permalink: /4-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, ensure that all youth and a substantial proportion of adults, both
-  men and women, achieve literacy and numeracy
+target: global_targets.4-6.title
 target_id: '4.6'
-graph_title: Proportion of population in a given age group achieving at least a fixed level
-  of proficiency in functional (a) literacy and (b) numeracy skills, by sex
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)
 un_designated_tier: '2'

--- a/meta/4-7-1.md
+++ b/meta/4-7-1.md
@@ -2,28 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-4.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
+graph_title: global_indicators.4-7-1.title
 graph_type: line
 indicator: 4.7.1
-indicator_name: "Extent to which (i) global citizenship education and (ii) education\
-  \ for sustainable development, including gender equality and human rights, are mainstreamed\
-  \ at all levels in: (a) national education policies; (b) curricula; (c) teacher\
-  \ education; and (d)\_student assessment"
+indicator_name: global_indicators.4-7-1.title
 indicator_sort_order: 04-07-01
 layout: indicator
 permalink: /4-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: "By 2030, ensure that all learners acquire the knowledge and skills needed\
-  \ to promote sustainable development, including, among others, through education\
-  \ for sustainable development and sustainable lifestyles, human rights, gender equality,\
-  \ promotion of a culture of peace and non-violence, global citizenship and appreciation\
-  \ of cultural diversity and of culture\u2019s contribution to sustainable development"
+target: global_targets.4-7.title
 target_id: '4.7'
-graph_title: "Extent to which (i) global citizenship education and (ii) education for sustainable\
-  \ development, including gender equality and human rights, are mainstreamed at all\
-  \ levels in: (a) national education policies; (b) curricula; (c) teacher education;\
-  \ and (d)\_student assessment"
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '3'
 ---

--- a/meta/4-a-1.md
+++ b/meta/4-a-1.md
@@ -3,18 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
-graph_title: "Proportion of schools with access to: (a)\_electricity; (b) the Internet\
-  \ for pedagogical purposes; (c) computers for pedagogical purposes; (d)\_adapted\
-  \ infrastructure and materials for students with disabilities; (e) basic drinking\
-  \ water; (f) single-sex basic sanitation facilities; and (g) basic handwashing facilities\
-  \ (as per the WASH indicator definitions)"
+graph_title: global_indicators.4-a-1.title
 graph_type: line
 indicator: 4.a.1
-indicator_name: "Proportion of schools with access to: (a)\_electricity; (b) the Internet\
-  \ for pedagogical purposes; (c) computers for pedagogical purposes; (d)\_adapted\
-  \ infrastructure and materials for students with disabilities; (e) basic drinking\
-  \ water; (f) single-sex basic sanitation facilities; and (g) basic handwashing facilities\
-  \ (as per the WASH indicator definitions)"
+indicator_name: global_indicators.4-a-1.title
 indicator_sort_order: 04-aa-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -24,9 +16,7 @@ reporting_status: complete
 sdg_goal: '4'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Science and Education of RA
-target: Build and upgrade education facilities that are child, disability and gender
-  sensitive and provide safe, non-violent, inclusive and effective learning environments
-  for all
+target: global_targets.4-a.title
 target_id: 4.a
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '2'

--- a/meta/4-b-1.md
+++ b/meta/4-b-1.md
@@ -3,26 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
+graph_title: global_indicators.4-b-1.title
 graph_type: line
 indicator: 4.b.1
 indicator_definition: Volume of official development assistance flows for scholarships
   by sector and type of study
-indicator_name: Volume of official development assistance flows for scholarships by
-  sector and type of study
+indicator_name: global_indicators.4-b-1.title
 indicator_sort_order: 04-bb-01
 layout: indicator
 permalink: /4-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2020, substantially expand globally the number of scholarships available
-  to developing countries, in particular least developed countries, small island developing
-  States and African countries, for enrolment in higher education, including vocational
-  training and information and communications technology, technical, engineering and
-  scientific programmes, in developed countries and other developing countries
+target: global_targets.4-b.title
 target_id: 4.b
-graph_title: Volume of official development assistance flows for scholarships by sector
-  and type of study
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'
 ---

--- a/meta/4-c-1.md
+++ b/meta/4-c-1.md
@@ -3,26 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-04-0C-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 218
   KB)
+graph_title: global_indicators.4-c-1.title
 graph_type: line
 indicator: 4.c.1
-indicator_name: 'Proportion of teachers in: (a) pre-primary; (b) primary; (c) lower
-  secondary; and (d) upper secondary education who have received at least the minimum
-  organized teacher training (e.g. pedagogical training) pre-service or in-service
-  required for teaching at the relevant level in a given country'
+indicator_name: global_indicators.4-c-1.title
 indicator_sort_order: 04-cc-01
 layout: indicator
 permalink: /4-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: By 2030, substantially increase the supply of qualified teachers, including
-  through international cooperation for teacher training in developing countries,
-  especially least developed countries and small island developing States
+target: global_targets.4-c.title
 target_id: 4.c
-graph_title: 'Proportion of teachers in: (a) pre-primary; (b) primary; (c) lower secondary;
-  and (d) upper secondary education who have received at least the minimum organized
-  teacher training (e.g. pedagogical training) pre-service or in-service required
-  for teaching at the relevant level in a given country'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)
 un_designated_tier: '1'

--- a/meta/5-1-1.md
+++ b/meta/5-1-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
+graph_title: global_indicators.5-1-1.title
 graph_type: line
 indicator: 5.1.1
-indicator_name: "Whether or not legal frameworks are in place to promote, enforce\
-  \ and monitor equality and non\u2011discrimination on the basis of sex"
+indicator_name: global_indicators.5-1-1.title
 indicator_sort_order: 05-01-01
 layout: indicator
 permalink: /5-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: End all forms of discrimination against all women and girls everywhere
+target: global_targets.5-1.title
 target_id: '5.1'
-graph_title: "Whether or not legal frameworks are in place to promote, enforce and monitor\
-  \ equality and non\u2011discrimination on the basis of sex"
 un_custodian_agency: UN Women,World Bank,OECD Development Centre
 un_designated_tier: '3'
 ---

--- a/meta/5-2-1.md
+++ b/meta/5-2-1.md
@@ -3,17 +3,13 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 518
   KB)
-graph_title: Proportion of ever-partnered women and girls aged 15 years and older
-  subjected to physical, sexual or psychological violence by a current or former intimate
-  partner in the previous 12 months, by form of violence and by age
+graph_title: global_indicators.5-2-1.title
 graph_type: line
 indicator: 5.2.1
 indicator_definition: Proportion of ever-partnered women and girls aged 15 years and
   older subjected to physical, sexual or psychological violence by a current or former
   intimate partner in the previous 12 months, by form of violence and by age
-indicator_name: Proportion of ever-partnered women and girls aged 15 years and older
-  subjected to physical, sexual or psychological violence by a current or former intimate
-  partner in the previous 12 months, by form of violence and by age
+indicator_name: global_indicators.5-2-1.title
 indicator_sort_order: 05-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -23,12 +19,11 @@ reporting_status: complete
 sdg_goal: '5'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: Eliminate all forms of violence against all women and girls in the public
-  and private spheres, including trafficking and sexual and other types of exploitation
+target: global_targets.5-2.title
 target_id: '5.2'
-un_custodian_agency: "United Nations Children\u2019s Fund (UNICEF) The United Nations\
-  \ Entity for Gender Equality and the Empowerment of Women (UN Women) United Nations\
-  \ Population Fund (UNFPA) World Health Organization (WHO) United Nations Office\
-  \ on Drugs and Crime (UNODC)  "
+un_custodian_agency: 'United Nations Children’s Fund (UNICEF) The United Nations Entity
+  for Gender Equality and the Empowerment of Women (UN Women) United Nations Population
+  Fund (UNFPA) World Health Organization (WHO) United Nations Office on Drugs and
+  Crime (UNODC)  '
 un_designated_tier: '2'
 ---

--- a/meta/5-2-2.md
+++ b/meta/5-2-2.md
@@ -3,29 +3,24 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 294
   KB)
+graph_title: global_indicators.5-2-2.title
 graph_type: line
 indicator: 5.2.2
 indicator_definition: Proportion of women and girls aged 15 years and older subjected
   to sexual violence by persons other than an intimate partner in the previous 12
   months, by age and place of occurrence
-indicator_name: Proportion of women and girls aged 15 years and older subjected to
-  sexual violence by persons other than an intimate partner in the previous 12 months,
-  by age and place of occurrence
+indicator_name: global_indicators.5-2-2.title
 indicator_sort_order: 05-02-02
 layout: indicator
 permalink: /5-2-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Eliminate all forms of violence against all women and girls in the public
-  and private spheres, including trafficking and sexual and other types of exploitation
+target: global_targets.5-2.title
 target_id: '5.2'
-graph_title: Proportion of women and girls aged 15 years and older subjected to sexual violence
-  by persons other than an intimate partner in the previous 12 months, by age and
-  place of occurrence
-un_custodian_agency: "United Nations Children\u2019s Fund (UNICEF) The United Nations\
-  \ Entity for Gender Equality and the Empowerment of Women (UN Women) United Nations\
-  \ Population Fund (UNFPA) World Health Organization (WHO) United Nations Office\
-  \ on Drugs and Crime (UNODC)  "
+un_custodian_agency: 'United Nations Children’s Fund (UNICEF) The United Nations Entity
+  for Gender Equality and the Empowerment of Women (UN Women) United Nations Population
+  Fund (UNFPA) World Health Organization (WHO) United Nations Office on Drugs and
+  Crime (UNODC)  '
 un_designated_tier: '2'
 ---

--- a/meta/5-3-1.md
+++ b/meta/5-3-1.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 207
   KB)
-graph_title: Proportion of women aged 20-24 years who were married or in a union before
-  age 15 and before age 18
+graph_title: global_indicators.5-3-1.title
 graph_type: line
 indicator: 5.3.1
-indicator_name: Proportion of women aged 20-24 years who were married or in a union
-  before age 15 and before age 18
+indicator_name: global_indicators.5-3-1.title
 indicator_sort_order: 05-03-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,8 +14,7 @@ permalink: /5-3-1/
 published: true
 reporting_status: complete
 sdg_goal: '5'
-target: Eliminate all harmful practices, such as child, early and forced marriage
-  and female genital mutilation
+target: global_targets.5-3.title
 target_id: '5.3'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '2'

--- a/meta/5-3-2.md
+++ b/meta/5-3-2.md
@@ -3,21 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 206
   KB)
+graph_title: global_indicators.5-3-2.title
 graph_type: line
 indicator: 5.3.2
-indicator_name: Proportion of girls and women aged 15-49 years who have undergone
-  female genital mutilation/cutting, by age
+indicator_name: global_indicators.5-3-2.title
 indicator_sort_order: 05-03-02
 layout: indicator
 permalink: /5-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Eliminate all harmful practices, such as child, early and forced marriage
-  and female genital mutilation
+target: global_targets.5-3.title
 target_id: '5.3'
-graph_title: Proportion of girls and women aged 15-49 years who have undergone female genital
-  mutilation/cutting, by age
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '2'
 ---

--- a/meta/5-4-1.md
+++ b/meta/5-4-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 337
   KB)
+graph_title: global_indicators.5-4-1.title
 graph_type: line
 indicator: 5.4.1
-indicator_name: Proportion of time spent on unpaid domestic and care work, by sex,
-  age and location
+indicator_name: global_indicators.5-4-1.title
 indicator_sort_order: 05-04-01
 layout: indicator
 permalink: /5-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Recognize and value unpaid care and domestic work through the provision of
-  public services, infrastructure and social protection policies and the promotion
-  of shared responsibility within the household and the family as nationally appropriate
+target: global_targets.5-4.title
 target_id: '5.4'
-graph_title: Proportion of time spent on unpaid domestic and care work, by sex, age and
-  location
 un_custodian_agency: UN Statistics Division (UNSD)
 un_designated_tier: '2'
 ---

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -4,14 +4,12 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: "Proportion of seats held by women in (a)\_national parliaments and (b)\
-  \ local governments"
+graph_title: global_indicators.5-5-1.title
 graph_type: line
 indicator: 5.5.1
 indicator_definition: Proportion of seats held by women in (a) national parliaments
   and (b) local governments
-indicator_name: "Proportion of seats held by women in (a)\_national parliaments and\
-  \ (b) local governments"
+indicator_name: global_indicators.5-5-1.title
 indicator_sort_order: 05-05-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -22,9 +20,7 @@ sdg_goal: '5'
 source_active_1: true
 source_organisation_1: Armstat, National Assemby of RA, Ministry of Territorial Administration
   and Development of RA
-target: "Ensure women\u2019s full and effective participation and equal opportunities\
-  \ for leadership at all levels of decision-making in political, economic and public\
-  \ life"
+target: global_targets.5-5.title
 target_id: '5.5'
 un_custodian_agency: Inter-Parliamentary Union (IPU)
 un_designated_tier: 1/2

--- a/meta/5-5-2.md
+++ b/meta/5-5-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 372
   KB)
-graph_title: Proportion of women in managerial positions
+graph_title: global_indicators.5-5-2.title
 graph_type: line
 indicator: 5.5.2
-indicator_name: Proportion of women in managerial positions
+indicator_name: global_indicators.5-5-2.title
 indicator_sort_order: 05-05-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ reporting_status: complete
 sdg_goal: '5'
 source_active_1: true
 source_organisation_1: Armstat
-target: "Ensure women\u2019s full and effective participation and equal opportunities\
-  \ for leadership at all levels of decision-making in political, economic and public\
-  \ life"
+target: global_targets.5-5.title
 target_id: '5.5'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -2,23 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
+graph_title: global_indicators.5-6-1.title
 graph_type: line
 indicator: 5.6.1
-indicator_name: Proportion of women aged 15-49 years who make their own informed decisions
-  regarding sexual relations, contraceptive use and reproductive health care
+indicator_name: global_indicators.5-6-1.title
 indicator_sort_order: 05-06-01
 layout: indicator
 permalink: /5-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Ensure universal access to sexual and reproductive health and reproductive
-  rights as agreed in accordance with the Programme of Action of the International
-  Conference on Population and Development and the Beijing Platform for Action and
-  the outcome documents of their review conferences
+target: global_targets.5-6.title
 target_id: '5.6'
-graph_title: Proportion of women aged 15-49 years who make their own informed decisions
-  regarding sexual relations, contraceptive use and reproductive health care
 un_custodian_agency: UNFPA
 un_designated_tier: '2'
 ---

--- a/meta/5-6-2.md
+++ b/meta/5-6-2.md
@@ -2,25 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
+graph_title: global_indicators.5-6-2.title
 graph_type: line
 indicator: 5.6.2
-indicator_name: Number of countries with laws and regulations that guarantee full
-  and equal access to women and men aged 15 years and older to sexual and reproductive
-  health care, information and education
+indicator_name: global_indicators.5-6-2.title
 indicator_sort_order: 05-06-02
 layout: indicator
 permalink: /5-6-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Ensure universal access to sexual and reproductive health and reproductive
-  rights as agreed in accordance with the Programme of Action of the International
-  Conference on Population and Development and the Beijing Platform for Action and
-  the outcome documents of their review conferences
+target: global_targets.5-6.title
 target_id: '5.6'
-graph_title: Number of countries with laws and regulations that guarantee full and equal
-  access to women and men aged 15 years and older to sexual and reproductive health
-  care, information and education
 un_custodian_agency: UNFPA
 un_designated_tier: '3'
 ---

--- a/meta/5-a-1.md
+++ b/meta/5-a-1.md
@@ -3,24 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.5-a-1.title
 graph_type: line
 indicator: 5.a.1
-indicator_name: (a) Proportion of total agricultural population with ownership or
-  secure rights over agricultural land, by sex; and (b) share of women among owners
-  or rights-bearers of agricultural land, by type of tenure
+indicator_name: global_indicators.5-a-1.title
 indicator_sort_order: 05-aa-01
 layout: indicator
 permalink: /5-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Undertake reforms to give women equal rights to economic resources, as well
-  as access to ownership and control over land and other forms of property, financial
-  services, inheritance and natural resources, in accordance with national laws
+target: global_targets.5-a.title
 target_id: 5.a
-graph_title: (a) Proportion of total agricultural population with ownership or secure rights
-  over agricultural land, by sex; and (b) share of women among owners or rights-bearers
-  of agricultural land, by type of tenure
 un_custodian_agency: United Nations Entity for Gender Equality and the Empowerment
   of Women (UN Women) United Nations Statistics Division (UNSD) Food and Agriculture
   Organization of the United Nations (FAO)

--- a/meta/5-a-2.md
+++ b/meta/5-a-2.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
+graph_title: global_indicators.5-a-2.title
 graph_type: line
 indicator: 5.a.2
-indicator_name: "Proportion of countries where the legal framework (including customary\
-  \ law) guarantees women\u2019s equal rights to land ownership and/or control"
+indicator_name: global_indicators.5-a-2.title
 indicator_sort_order: 05-aa-02
 layout: indicator
 permalink: /5-a-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Undertake reforms to give women equal rights to economic resources, as well
-  as access to ownership and control over land and other forms of property, financial
-  services, inheritance and natural resources, in accordance with national laws
+target: global_targets.5-a.title
 target_id: 5.a
-graph_title: "Proportion of countries where the legal framework (including customary law)\
-  \ guarantees women\u2019s equal rights to land ownership and/or control"
 un_custodian_agency: FAO,World Bank, UN Women
 un_designated_tier: '2'
 ---

--- a/meta/5-b-1.md
+++ b/meta/5-b-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
-graph_title: Proportion of individuals who own a mobile telephone, by sex
+graph_title: global_indicators.5-b-1.title
 graph_type: line
 indicator: 5.b.1
-indicator_name: Proportion of individuals who own a mobile telephone, by sex
+indicator_name: global_indicators.5-b-1.title
 indicator_sort_order: 05-bb-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,8 +17,7 @@ reporting_status: complete
 sdg_goal: '5'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: Enhance the use of enabling technology, in particular information and communications
-  technology, to promote the empowerment of women
+target: global_targets.5-b.title
 target_id: 5.b
 un_custodian_agency: International Telecommunication Union (ITU)
 un_designated_tier: '1'

--- a/meta/5-c-1.md
+++ b/meta/5-c-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
+graph_title: global_indicators.5-c-1.title
 graph_type: line
 indicator: 5.c.1
-indicator_name: "Proportion of countries with systems to track and make public allocations\
-  \ for gender equality and women\u2019s empowerment"
+indicator_name: global_indicators.5-c-1.title
 indicator_sort_order: 05-cc-01
 layout: indicator
 permalink: /5-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: Adopt and strengthen sound policies and enforceable legislation for the promotion
-  of gender equality and the empowerment of all women and girls at all levels
+target: global_targets.5-c.title
 target_id: 5.c
-graph_title: "Proportion of countries with systems to track and make public allocations\
-  \ for gender equality and women\u2019s empowerment"
 un_custodian_agency: UN Women,OECD
 un_designated_tier: '2'
 ---

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: Proportion of population using safely managed drinking water services
+graph_title: global_indicators.6-1-1.title
 graph_type: line
 indicator: 6.1.1
-indicator_name: Proportion of population using safely managed drinking water services
+indicator_name: global_indicators.6-1-1.title
 indicator_sort_order: 06-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,8 +16,7 @@ reporting_status: complete
 sdg_goal: '6'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: By 2030, achieve universal and equitable access to safe and affordable drinking
-  water for all
+target: global_targets.6-1.title
 target_id: '6.1'
 un_custodian_agency: World Health Organisation (WHO), United Nations Children's Emergency
   Fund (UNICEF)

--- a/meta/6-2-1.md
+++ b/meta/6-2-1.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: Proportion of population using safely managed sanitation services, including
-  a hand-washing facility with soap and water
+graph_title: global_indicators.6-2-1.title
 graph_type: line
 indicator: 6.2.1
-indicator_name: Proportion of population using safely managed sanitation services,
-  including a hand-washing facility with soap and water
+indicator_name: global_indicators.6-2-1.title
 indicator_sort_order: 06-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,9 +16,7 @@ reporting_status: complete
 sdg_goal: '6'
 source_active_1: true
 source_organisation_1: Armstat, ILCS
-target: By 2030, achieve access to adequate and equitable sanitation and hygiene for
-  all and end open defecation, paying special attention to the needs of women and
-  girls and those in vulnerable situations
+target: global_targets.6-2.title
 target_id: '6.2'
 un_custodian_agency: World Health Organisation (WHO), United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
+graph_title: global_indicators.6-3-1.title
 graph_type: line
 indicator: 6.3.1
-indicator_name: Proportion of wastewater safely treated
+indicator_name: global_indicators.6-3-1.title
 indicator_sort_order: 06-03-01
 layout: indicator
 permalink: /6-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, improve water quality by reducing pollution, eliminating dumping
-  and minimizing release of hazardous chemicals and materials, halving the proportion
-  of untreated wastewater and substantially increasing recycling and safe reuse globally
+target: global_targets.6-3.title
 target_id: '6.3'
-graph_title: Proportion of wastewater safely treated
 un_custodian_agency: WHO, UN-Habitat,UNSD
 un_designated_tier: '2'
 ---

--- a/meta/6-3-2.md
+++ b/meta/6-3-2.md
@@ -3,24 +3,22 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.6-3-2.title
 graph_type: line
 indicator: 6.3.2
-indicator_definition: "Proportion of water bodies (area) in a country with good ambient\
-  \ water quality compared to all water bodies in the country. \u201CGood\u201D indicates\
-  \ an ambient water quality that does not damage ecosystem function and human health\
-  \ according to core ambient water quality indicators."
-indicator_name: Proportion of bodies of water with good ambient water quality
+indicator_definition: Proportion of water bodies (area) in a country with good ambient
+  water quality compared to all water bodies in the country. “Good” indicates an ambient
+  water quality that does not damage ecosystem function and human health according
+  to core ambient water quality indicators.
+indicator_name: global_indicators.6-3-2.title
 indicator_sort_order: 06-03-02
 layout: indicator
 permalink: /6-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, improve water quality by reducing pollution, eliminating dumping
-  and minimizing release of hazardous chemicals and materials, halving the proportion
-  of untreated wastewater and substantially increasing recycling and safe reuse globally
+target: global_targets.6-3.title
 target_id: '6.3'
-graph_title: Proportion of bodies of water with good ambient water quality
 un_custodian_agency: United Nations Environment Programme (UNEP) (GEMS/Water)
 un_designated_tier: '3'
 ---

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
+graph_title: global_indicators.6-4-1.title
 graph_type: line
 indicator: 6.4.1
-indicator_name: Change in water-use efficiency over time
+indicator_name: global_indicators.6-4-1.title
 indicator_sort_order: 06-04-01
 layout: indicator
 permalink: /6-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, substantially increase water-use efficiency across all sectors and
-  ensure sustainable withdrawals and supply of freshwater to address water scarcity
-  and substantially reduce the number of people suffering from water scarcity
+target: global_targets.6-4.title
 target_id: '6.4'
-graph_title: Change in water-use efficiency over time
 un_custodian_agency: FAO
 un_designated_tier: '2'
 ---

--- a/meta/6-4-2.md
+++ b/meta/6-4-2.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: 'Level of water stress: freshwater withdrawal as a proportion of available
-  freshwater resources'
+graph_title: global_indicators.6-4-2.title
 graph_type: line
 indicator: 6.4.2
-indicator_name: 'Level of water stress: freshwater withdrawal as a proportion of available
-  freshwater resources'
+indicator_name: global_indicators.6-4-2.title
 indicator_sort_order: 06-04-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,9 +17,7 @@ sdg_goal: '6'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Nature Protection of RA, Ministry of Emergency
   Situations, Armenian State Hydrometeorological and Monitoring Service
-target: By 2030, substantially increase water-use efficiency across all sectors and
-  ensure sustainable withdrawals and supply of freshwater to address water scarcity
-  and substantially reduce the number of people suffering from water scarcity
+target: global_targets.6-4.title
 target_id: '6.4'
 un_custodian_agency: FAO
 un_designated_tier: '1'

--- a/meta/6-5-1.md
+++ b/meta/6-5-1.md
@@ -3,19 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-06-05-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 410
   KB)
+graph_title: global_indicators.6-5-1.title
 graph_type: line
 indicator: 6.5.1
-indicator_name: Degree of integrated water resources management implementation (0-100)
+indicator_name: global_indicators.6-5-1.title
 indicator_sort_order: 06-05-01
 layout: indicator
 permalink: /6-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, implement integrated water resources management at all levels, including
-  through transboundary cooperation as appropriate
+target: global_targets.6-5.title
 target_id: '6.5'
-graph_title: Degree of integrated water resources management implementation (0-100)
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '1'
 ---

--- a/meta/6-5-2.md
+++ b/meta/6-5-2.md
@@ -4,12 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: Proportion of transboundary basin area with an operational arrangement
-  for water cooperation
+graph_title: global_indicators.6-5-2.title
 graph_type: line
 indicator: 6.5.2
-indicator_name: Proportion of transboundary basin area with an operational arrangement
-  for water cooperation
+indicator_name: global_indicators.6-5-2.title
 indicator_sort_order: 06-05-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,8 +17,7 @@ reporting_status: complete
 sdg_goal: '6'
 source_active_1: true
 source_organisation_1: Ministry of Nature Protection of RA
-target: By 2030, implement integrated water resources management at all levels, including
-  through transboundary cooperation as appropriate
+target: global_targets.6-5.title
 target_id: '6.5'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute for Statistics (UNESCO-UIS) United Nations Economic Commission for Europe

--- a/meta/6-6-1.md
+++ b/meta/6-6-1.md
@@ -2,19 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
+graph_title: global_indicators.6-6-1.title
 graph_type: line
 indicator: 6.6.1
-indicator_name: Change in the extent of water-related ecosystems over time
+indicator_name: global_indicators.6-6-1.title
 indicator_sort_order: 06-06-01
 layout: indicator
 permalink: /6-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2020, protect and restore water-related ecosystems, including mountains,
-  forests, wetlands, rivers, aquifers and lakes
+target: global_targets.6-6.title
 target_id: '6.6'
-graph_title: Change in the extent of water-related ecosystems over time
 un_custodian_agency: UNEP
 un_designated_tier: '3'
 ---

--- a/meta/6-a-1.md
+++ b/meta/6-a-1.md
@@ -3,30 +3,25 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 398
   KB)
+graph_title: global_indicators.6-a-1.title
 graph_type: line
 indicator: 6.a.1
-indicator_definition: "The amount of water and sanitation-related Official Development\
-  \ Assistance (ODA) is a quantifiable measurement as a proxy for \u201Cinternational\
-  \ cooperation and capacity development support\u201D in financial terms. It is essential\
-  \ to be able to assess ODA in proportion with how much of it is included in the\
-  \ government budget to gain a better understanding of whether donors are aligned\
-  \ with national governments while highlighting total water and sanitation ODA disbursements\
-  \ to developing countries over time."
-indicator_name: Amount of water- and sanitation-related official development assistance
-  that is part of a government-coordinated spending plan
+indicator_definition: The amount of water and sanitation-related Official Development
+  Assistance (ODA) is a quantifiable measurement as a proxy for “international cooperation
+  and capacity development support” in financial terms. It is essential to be able
+  to assess ODA in proportion with how much of it is included in the government budget
+  to gain a better understanding of whether donors are aligned with national governments
+  while highlighting total water and sanitation ODA disbursements to developing countries
+  over time.
+indicator_name: global_indicators.6-a-1.title
 indicator_sort_order: 06-aa-01
 layout: indicator
 permalink: /6-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: By 2030, expand international cooperation and capacity-building support to
-  developing countries in water- and sanitation-related activities and programmes,
-  including water harvesting, desalination, water efficiency, wastewater treatment,
-  recycling and reuse technologies
+target: global_targets.6-a.title
 target_id: 6.a
-graph_title: Amount of water- and sanitation-related official development assistance that
-  is part of a government-coordinated spending plan
 un_custodian_agency: World Health Organization (WHO) United Nations Environment Programme
   (UNEP) Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/6-b-1.md
+++ b/meta/6-b-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
+graph_title: global_indicators.6-b-1.title
 graph_type: line
 indicator: 6.b.1
-indicator_name: Proportion of local administrative units with established and operational
-  policies and procedures for participation of local communities in water and sanitation
-  management
+indicator_name: global_indicators.6-b-1.title
 indicator_sort_order: 06-bb-01
 layout: indicator
 permalink: /6-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: Support and strengthen the participation of local communities in improving
-  water and sanitation management
+target: global_targets.6-b.title
 target_id: 6.b
-graph_title: Proportion of local administrative units with established and operational policies
-  and procedures for participation of local communities in water and sanitation management
 un_custodian_agency: WHO,UNEP, OECD
 un_designated_tier: '1'
 ---

--- a/meta/7-1-1.md
+++ b/meta/7-1-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 212
   KB)
-graph_title: Proportion of population with access to electricity
+graph_title: global_indicators.7-1-1.title
 graph_type: line
 indicator: 7.1.1
-indicator_name: Proportion of population with access to electricity
+indicator_name: global_indicators.7-1-1.title
 indicator_sort_order: 07-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,8 +16,7 @@ reporting_status: complete
 sdg_goal: '7'
 source_active_1: true
 source_organisation_1: Armstat, ILCS
-target: By 2030, ensure universal access to affordable, reliable and modern energy
-  services
+target: global_targets.7-1.title
 target_id: '7.1'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/7-1-2.md
+++ b/meta/7-1-2.md
@@ -4,18 +4,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-07-01-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 232
   KB)
-graph_title: Proportion of population with primary reliance on clean fuels and technology
+graph_title: global_indicators.7-1-2.title
 graph_type: line
 indicator: 7.1.2
-indicator_definition: "Proportion of population with primary reliance on clean fuels\
-  \ and technology is calculated as the number of people using clean fuels and technologies\
-  \ for cooking, heating and lighting divided by total population reporting that any\
-  \ cooking, heating or lighting, expressed as percentage. \u201CClean\u201D is defined\
-  \ by the emission rate targets and specific fuel recommendations (i.e. against unprocessed\
-  \ coal and kerosene) included in the normative guidance WHO guidelines for indoor\
-  \ air quality: household fuel combustion."
-indicator_name: Proportion of population with primary reliance on clean fuels and
-  technology
+indicator_definition: 'Proportion of population with primary reliance on clean fuels
+  and technology is calculated as the number of people using clean fuels and technologies
+  for cooking, heating and lighting divided by total population reporting that any
+  cooking, heating or lighting, expressed as percentage. “Clean” is defined by the
+  emission rate targets and specific fuel recommendations (i.e. against unprocessed
+  coal and kerosene) included in the normative guidance WHO guidelines for indoor
+  air quality: household fuel combustion.'
+indicator_name: global_indicators.7-1-2.title
 indicator_sort_order: 07-01-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -25,8 +24,7 @@ reporting_status: complete
 sdg_goal: '7'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: By 2030, ensure universal access to affordable, reliable and modern energy
-  services
+target: global_targets.7-1.title
 target_id: '7.1'
 un_custodian_agency: International Trade Centre (ITC) United Nations Conference on
   Trade and Development (UNCTAD) The World Trade Organization (WTO)

--- a/meta/7-2-1.md
+++ b/meta/7-2-1.md
@@ -1,13 +1,13 @@
 ---
-computation_units: "\u2105"
+computation_units: ℅
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-07-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 216
   KB)
-graph_title: Renewable energy share in the total final energy consumption
+graph_title: global_indicators.7-2-1.title
 graph_type: line
 indicator: 7.2.1
-indicator_name: Renewable energy share in the total final energy consumption
+indicator_name: global_indicators.7-2-1.title
 indicator_sort_order: 07-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,8 +17,7 @@ reporting_status: complete
 sdg_goal: '7'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, increase substantially the share of renewable energy in the global
-  energy mix
+target: global_targets.7-2.title
 target_id: '7.2'
 un_custodian_agency: International Energy Agency (IEA) United Nations Statistics Division
   (UNSD) United Nations' inter-agency mechanism on energy (UN Energy) and the SE4ALL

--- a/meta/7-3-1.md
+++ b/meta/7-3-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 192
   KB)
-graph_title: Energy intensity measured in terms of primary energy and GDP
+graph_title: global_indicators.7-3-1.title
 graph_type: line
 indicator: 7.3.1
-indicator_name: Energy intensity measured in terms of primary energy and GDP
+indicator_name: global_indicators.7-3-1.title
 indicator_sort_order: 07-03-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '7'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, double the global rate of improvement in energy efficiency
+target: global_targets.7-3.title
 target_id: '7.3'
 un_custodian_agency: International Energy Agency (IEA) United Nations Statistics Division
   (UNSD) United Nations' inter-agency mechanism on energy (UN Energy) and the SE4ALL

--- a/meta/7-a-1.md
+++ b/meta/7-a-1.md
@@ -3,26 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-7.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 111
   KB)
+graph_title: global_indicators.7-a-1.title
 graph_type: line
 indicator: 7.a.1
 indicator_definition: Mobilized amount of United States dollars per year starting
   in 2020 accountable towards the $100 billion commitment.
-indicator_name: International financial flows to developing countries in support of
-  clean energy research and development and renewable energy production, including
-  in hybrid systems
+indicator_name: global_indicators.7-a-1.title
 indicator_sort_order: 07-aa-01
 layout: indicator
 permalink: /7-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: By 2030, enhance international cooperation to facilitate access to clean energy
-  research and technology, including renewable energy, energy efficiency and advanced
-  and cleaner fossil-fuel technology, and promote investment in energy infrastructure
-  and clean energy technology
+target: global_targets.7-a.title
 target_id: 7.a
-graph_title: International financial flows to developing countries in support of clean energy
-  research and development and renewable energy production, including in hybrid systems
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '2'
 ---

--- a/meta/7-b-1.md
+++ b/meta/7-b-1.md
@@ -3,25 +3,18 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-7.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.7-b-1.title
 graph_type: line
 indicator: 7.b.1
-indicator_name: Investments in energy efficiency as a proportion of GDP and the amount
-  of foreign direct investment in financial transfer for infrastructure and technology
-  to sustainable development services
+indicator_name: global_indicators.7-b-1.title
 indicator_sort_order: 07-bb-01
 layout: indicator
 permalink: /7-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: By 2030, expand infrastructure and upgrade technology for supplying modern
-  and sustainable energy services for all in developing countries, in particular least
-  developed countries, small island developing States and landlocked developing countries,
-  in accordance with their respective programmes of support
+target: global_targets.7-b.title
 target_id: 7.b
-graph_title: Investments in energy efficiency as a proportion of GDP and the amount of foreign
-  direct investment in financial transfer for infrastructure and technology to sustainable
-  development services
 un_custodian_agency: International Energy Agency (IEA)
 un_designated_tier: '3'
 ---

--- a/meta/8-1-1.md
+++ b/meta/8-1-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-01-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 232
   KB)
-graph_title: Annual growth rate of real GDP per capita
+graph_title: global_indicators.8-1-1.title
 graph_type: line
 indicator: 8.1.1
-indicator_name: Annual growth rate of real GDP per capita
+indicator_name: global_indicators.8-1-1.title
 indicator_sort_order: 08-01-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat
-target: Sustain per capita economic growth in accordance with national circumstances
-  and, in particular, at least 7 per cent gross domestic product growth per annum
-  in the least developed countries
+target: global_targets.8-1.title
 target_id: '8.1'
 un_custodian_agency: United Nations Statistics Division (UNSD)
 un_designated_tier: '1'

--- a/meta/8-10-1.md
+++ b/meta/8-10-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
+graph_title: global_indicators.8-10-1.title
 graph_type: line
 indicator: 8.10.1
-indicator_name: (a) Number of commercial bank branches per 100,000 adults and (b)
-  number of automated teller machines (ATMs) per 100,000 adults
+indicator_name: global_indicators.8-10-1.title
 indicator_sort_order: 08-10-01
 layout: indicator
 permalink: /8-10-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Strengthen the capacity of domestic financial institutions to encourage and
-  expand access to banking, insurance and financial services for all
+target: global_targets.8-10.title
 target_id: '8.10'
-graph_title: (a) Number of commercial bank branches per 100,000 adults and (b) number of
-  automated teller machines (ATMs) per 100,000 adults
 un_custodian_agency: IMF
 un_designated_tier: '1'
 ---

--- a/meta/8-10-2.md
+++ b/meta/8-10-2.md
@@ -3,12 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
-graph_title: Proportion of adults (15 years and older) with an account at a bank or
-  other financial institution or with a mobile-money-service provider
+graph_title: global_indicators.8-10-2.title
 graph_type: line
 indicator: 8.10.2
-indicator_name: Proportion of adults (15 years and older) with an account at a bank
-  or other financial institution or with a mobile-money-service provider
+indicator_name: global_indicators.8-10-2.title
 indicator_sort_order: 08-10-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,8 +16,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat, DHS
-target: 0 Strengthen the capacity of domestic financial institutions to encourage
-  and expand access to banking, insurance and financial services for all
+target: global_targets.8-1.title
 target_id: '8.1'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/8-2-1.md
+++ b/meta/8-2-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 384
   KB)
-graph_title: Annual growth rate of real GDP per employed person
+graph_title: global_indicators.8-2-1.title
 graph_type: line
 indicator: 8.2.1
-indicator_name: Annual growth rate of real GDP per employed person
+indicator_name: global_indicators.8-2-1.title
 indicator_sort_order: 08-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat
-target: Achieve higher levels of economic productivity through diversification, technological
-  upgrading and innovation, including through a focus on high-value added and labour-intensive
-  sectors
+target: global_targets.8-2.title
 target_id: '8.2'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-3-1.md
+++ b/meta/8-3-1.md
@@ -3,12 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 231
   KB)
-graph_title: "Proportion of informal employment in non\u2011agriculture employment,\
-  \ by sex"
+graph_title: global_indicators.8-3-1.title
 graph_type: line
 indicator: 8.3.1
-indicator_name: "Proportion of informal employment in non\u2011agriculture employment,\
-  \ by sex"
+indicator_name: global_indicators.8-3-1.title
 indicator_sort_order: 08-03-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,10 +16,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat, LFS
-target: Promote development-oriented policies that support productive activities,
-  decent job creation, entrepreneurship, creativity and innovation, and encourage
-  the formalization and growth of micro-, small- and medium-sized enterprises, including
-  through access to financial services
+target: global_targets.8-3.title
 target_id: '8.3'
 un_custodian_agency: International Labour Organisation (ILO)
 un_designated_tier: '2'

--- a/meta/8-4-1.md
+++ b/meta/8-4-1.md
@@ -3,23 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.8-4-1.title
 graph_type: line
 indicator: 8.4.1
-indicator_name: Material footprint, material footprint per capita, and material footprint
-  per GDP
+indicator_name: global_indicators.8-4-1.title
 indicator_sort_order: 08-04-01
 layout: indicator
 permalink: /8-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Improve progressively, through 2030, global resource efficiency in consumption
-  and production and endeavour to decouple economic growth from environmental degradation,
-  in accordance with the 10-Year Framework of Programmes on Sustainable Consumption
-  and Production, with developed countries taking the lead
+target: global_targets.8-4.title
 target_id: '8.4'
-graph_title: Material footprint, material footprint per capita, and material footprint per
-  GDP
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '3'
 ---

--- a/meta/8-4-2.md
+++ b/meta/8-4-2.md
@@ -3,12 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 58.7
   KB)
-graph_title: Domestic material consumption, domestic material consumption per capita,
-  and domestic material consumption per GDP
+graph_title: global_indicators.8-4-2.title
 graph_type: line
 indicator: 8.4.2
-indicator_name: Domestic material consumption, domestic material consumption per capita,
-  and domestic material consumption per GDP
+indicator_name: global_indicators.8-4-2.title
 indicator_sort_order: 08-04-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,10 +16,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat
-target: Improve progressively, through 2030, global resource efficiency in consumption
-  and production and endeavour to decouple economic growth from environmental degradation,
-  in accordance with the 10-Year Framework of Programmes on Sustainable Consumption
-  and Production, with developed countries taking the lead
+target: global_targets.8-4.title
 target_id: '8.4'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '1'

--- a/meta/8-5-1.md
+++ b/meta/8-5-1.md
@@ -3,22 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 317
   KB)
+graph_title: global_indicators.8-5-1.title
 graph_type: line
 indicator: 8.5.1
-indicator_name: 8.5.1 Average hourly earnings of female and male employees, by occupation,
-  age and persons with disabilities
+indicator_name: global_indicators.8-5-1.title
 indicator_sort_order: 08-05-01
 layout: indicator
 permalink: /8-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: 8.5 By 2030, achieve full and productive employment and decent work for all
-  women and men, including for young people and persons with disabilities, and equal
-  pay for work of equal value
+target: global_targets.8-5.title
 target_id: '8.5'
-graph_title: Average hourly earnings of female and male employees, by occupation, age and
-  persons with disabilities
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: 2
 ---

--- a/meta/8-5-2.md
+++ b/meta/8-5-2.md
@@ -4,7 +4,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-05-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 383
   KB)
-graph_title: Unemployment rate, by sex, age and persons with disabilities
+graph_title: global_indicators.8-5-2.title
 graph_type: line
 indicator: 8.5.2
 indicator_definition: The unemployment rate is a useful measure of the underutilization
@@ -17,7 +17,7 @@ indicator_definition: The unemployment rate is a useful measure of the underutil
   often coincide with recessionary periods or in some cases with the beginning of
   an expansionary period as persons previously not in the labour market begin to test
   conditions through an active job search.
-indicator_name: Unemployment rate, by sex, age and persons with disabilities
+indicator_name: global_indicators.8-5-2.title
 indicator_sort_order: 08-05-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -27,9 +27,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat
-target: By 2030, achieve full and productive employment and decent work for all women
-  and men, including for young people and persons with disabilities, and equal pay
-  for work of equal value
+target: global_targets.8-5.title
 target_id: '8.5'
 un_custodian_agency: International labour organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-6-1.md
+++ b/meta/8-6-1.md
@@ -4,16 +4,14 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
   KB)
-graph_title: Proportion of youth (aged 15-24 years) not in education, employment or
-  training
+graph_title: global_indicators.8-6-1.title
 graph_type: line
 indicator: 8.6.1
 indicator_definition: This proportion of youth (aged 15-24 years) not in education,
   employment or training, also known as "the NEET rate", conveys the number of young
   persons not in education, employment or training as a percentage of the total youth
   population.
-indicator_name: Proportion of youth (aged 15-24 years) not in education, employment
-  or training
+indicator_name: global_indicators.8-6-1.title
 indicator_sort_order: 08-06-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -23,8 +21,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat, LFS
-target: By 2020, substantially reduce the proportion of youth not in employment, education
-  or training
+target: global_targets.8-6.title
 target_id: '8.6'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-7-1.md
+++ b/meta/8-7-1.md
@@ -3,12 +3,10 @@ computation_units: number
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-07-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
-graph_title: "Proportion and number of children aged 5\u201117\_years engaged in child\
-  \ labour, by sex and age"
+graph_title: global_indicators.8-7-1.title
 graph_type: line
 indicator: 8.7.1
-indicator_name: "Proportion and number of children aged 5\u201117\_years engaged in\
-  \ child labour, by sex and age"
+indicator_name: global_indicators.8-7-1.title
 indicator_sort_order: 08-07-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -18,10 +16,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat, Armenia National Child Labour Survey 2015
-target: Take immediate and effective measures to eradicate forced labour, end modern
-  slavery and human trafficking and secure the prohibition and elimination of the
-  worst forms of child labour, including recruitment and use of child soldiers, and
-  by 2025 end child labour in all its forms
+target: global_targets.8-7.title
 target_id: '8.7'
 un_custodian_agency: ILO,UNICEF
 un_designated_tier: '2'

--- a/meta/8-8-1.md
+++ b/meta/8-8-1.md
@@ -4,12 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-08-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 381
   KB)
-graph_title: Frequency rates of fatal and non-fatal occupational injuries, by sex
-  and migrant status
+graph_title: global_indicators.8-8-1.title
 graph_type: line
 indicator: 8.8.1
-indicator_name: Frequency rates of fatal and non-fatal occupational injuries, by sex
-  and migrant status
+indicator_name: global_indicators.8-8-1.title
 indicator_sort_order: 08-08-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -19,9 +17,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: Armstat
-target: Protect labour rights and promote safe and secure working environments for
-  all workers, including migrant workers, in particular women migrants, and those
-  in precarious employment
+target: global_targets.8-8.title
 target_id: '8.8'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '2'

--- a/meta/8-8-2.md
+++ b/meta/8-8-2.md
@@ -2,24 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
+graph_title: global_indicators.8-8-2.title
 graph_type: line
 indicator: 8.8.2
-indicator_name: Level of national compliance of labour rights (freedom of association
-  and collective bargaining) based on International Labour Organization (ILO) textual
-  sources and national legislation, by sex and migrant status
+indicator_name: global_indicators.8-8-2.title
 indicator_sort_order: 08-08-02
 layout: indicator
 permalink: /8-8-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: ' Protect labour rights and promote safe and secure working environments for
-  all workers, including migrant workers, in particular women migrants, and those
-  in precarious employment'
+target: global_targets.8-8.title
 target_id: '8.8'
-graph_title: Level of national compliance of labour rights (freedom of association and collective
-  bargaining) based on International Labour Organization (ILO) textual sources and
-  national legislation, by sex and migrant status
 un_custodian_agency: ILO
 un_designated_tier: '3'
 ---

--- a/meta/8-9-1.md
+++ b/meta/8-9-1.md
@@ -3,21 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 526
   KB)
+graph_title: global_indicators.8-9-1.title
 graph_type: line
 indicator: 8.9.1
 indicator_definition: Tourism direct GDP as a proportion of total GDP and in growth
   rate
-indicator_name: Tourism direct GDP as a proportion of total GDP and in growth rate
+indicator_name: global_indicators.8-9-1.title
 indicator_sort_order: 08-09-01
 layout: indicator
 permalink: /8-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2030, devise and implement policies to promote sustainable tourism that
-  creates jobs and promotes local culture and products
+target: global_targets.8-9.title
 target_id: '8.9'
-graph_title: Tourism direct GDP as a proportion of total GDP and in growth rate
 un_custodian_agency: World Tourism Organization (UNTWO)
 un_designated_tier: '2'
 ---

--- a/meta/8-9-2.md
+++ b/meta/8-9-2.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 526
   KB)
+graph_title: global_indicators.8-9-2.title
 graph_type: line
 indicator: 8.9.2
-indicator_name: Proportion of jobs in sustainable tourism industries out of total
-  tourism jobs
+indicator_name: global_indicators.8-9-2.title
 indicator_sort_order: 08-09-02
 layout: indicator
 permalink: /8-9-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2030, devise and implement policies to promote sustainable tourism that
-  creates jobs and promotes local culture and products
+target: global_targets.8-9.title
 target_id: '8.9'
-graph_title: Proportion of jobs in sustainable tourism industries out of total tourism jobs
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '3'
 ---

--- a/meta/8-a-1.md
+++ b/meta/8-a-1.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208
   KB)
+graph_title: global_indicators.8-a-1.title
 graph_type: line
 indicator: 8.a.1
-indicator_name: Aid for Trade commitments and disbursements
+indicator_name: global_indicators.8-a-1.title
 indicator_sort_order: 08-aa-01
 layout: indicator
 permalink: /8-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: Increase Aid for Trade support for developing countries, in particular least
-  developed countries, including through the Enhanced Integrated Framework for Trade-related
-  Technical Assistance to Least Developed Countries
+target: global_targets.8-a.title
 target_id: 8.a
-graph_title: Aid for Trade commitments and disbursements
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'
 ---

--- a/meta/8-b-1.md
+++ b/meta/8-b-1.md
@@ -2,21 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
+graph_title: global_indicators.8-b-1.title
 graph_type: line
 indicator: 8.b.1
-indicator_name: Existence of a developed and operationalized national strategy for
-  youth employment, as a distinct strategy or as part of a national employment strategy
+indicator_name: global_indicators.8-b-1.title
 indicator_sort_order: 08-bb-01
 layout: indicator
 permalink: /8-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: By 2020, develop and operationalize a global strategy for youth employment
-  and implement the Global Jobs Pact of the International Labour Organization
+target: global_targets.8-b.title
 target_id: 8.b
-graph_title: Existence of a developed and operationalized national strategy for youth employment,
-  as a distinct strategy or as part of a national employment strategy
 un_custodian_agency: ILO
 un_designated_tier: '3'
 ---

--- a/meta/9-1-1.md
+++ b/meta/9-1-1.md
@@ -2,22 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)
+graph_title: global_indicators.9-1-1.title
 graph_type: line
 indicator: 9.1.1
-indicator_name: "Proportion of the rural population who live within 2\_km of an all-season\
-  \ road"
+indicator_name: global_indicators.9-1-1.title
 indicator_sort_order: 09-01-01
 layout: indicator
 permalink: /9-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Develop quality, reliable, sustainable and resilient infrastructure, including
-  regional and trans-border infrastructure, to support economic development and human
-  well-being, with a focus on affordable and equitable access for all
+target: global_targets.9-1.title
 target_id: '9.1'
-graph_title: "Proportion of the rural population who live within 2\_km of an all-season\
-  \ road"
 un_custodian_agency: World Bank
 un_designated_tier: '3'
 ---

--- a/meta/9-1-2.md
+++ b/meta/9-1-2.md
@@ -3,10 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 375
   KB)
-graph_title: Passenger and freight volumes, by mode of transport
+graph_title: global_indicators.9-1-2.title
 graph_type: line
 indicator: 9.1.2
-indicator_name: Passenger and freight volumes, by mode of transport
+indicator_name: global_indicators.9-1-2.title
 indicator_sort_order: 09-01-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,9 +16,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: Armstat
-target: Develop quality, reliable, sustainable and resilient infrastructure, including
-  regional and trans-border infrastructure, to support economic development and human
-  well-being, with a focus on affordable and equitable access for all
+target: global_targets.9-1.title
 target_id: '9.1'
 un_custodian_agency: International Civil Aviation Organization (ICAO)
 un_designated_tier: '1'

--- a/meta/9-2-1.md
+++ b/meta/9-2-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 217
   KB)
-graph_title: Manufacturing value added as a proportion of GDP and per capita
+graph_title: global_indicators.9-2-1.title
 graph_type: line
 indicator: 9.2.1
 indicator_definition: Manufacturing value added (MVA) is the total value of goods
@@ -12,7 +12,7 @@ indicator_definition: Manufacturing value added (MVA) is the total value of good
   period. It can be presented in percentage to gross domestic product (GDP) as well
   as per capita for any reference year. MVA growth rates are given at constant prices
   (in Chained Volume Measures [CVM]).
-indicator_name: Manufacturing value added as a proportion of GDP and per capita
+indicator_name: global_indicators.9-2-1.title
 indicator_sort_order: 09-02-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -20,9 +20,7 @@ permalink: /9-2-1/
 published: true
 reporting_status: complete
 sdg_goal: '9'
-target: "Promote inclusive and sustainable industrialization and, by 2030, significantly\
-  \ raise industry\u2019s share of employment and gross domestic product, in line\
-  \ with national circumstances, and double its share in least developed countries"
+target: global_targets.9-2.title
 target_id: '9.2'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-2-2.md
+++ b/meta/9-2-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 323
   KB)
-graph_title: Manufacturing employment as a proportion of total employment
+graph_title: global_indicators.9-2-2.title
 graph_type: line
 indicator: 9.2.2
-indicator_name: Manufacturing employment as a proportion of total employment
+indicator_name: global_indicators.9-2-2.title
 indicator_sort_order: 09-02-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,9 +17,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: Armstat, LFS
-target: "Promote inclusive and sustainable industrialization and, by 2030, significantly\
-  \ raise industry\u2019s share of employment and gross domestic product, in line\
-  \ with national circumstances, and double its share in least developed countries"
+target: global_targets.9-2.title
 target_id: '9.2'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -3,20 +3,18 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
+graph_title: global_indicators.9-3-1.title
 graph_type: line
 indicator: 9.3.1
-indicator_name: Proportion of small-scale industries in total industry value added
+indicator_name: global_indicators.9-3-1.title
 indicator_sort_order: 09-03-01
 layout: indicator
 permalink: /9-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Increase the access of small-scale industrial and other enterprises, in particular
-  in developing countries, to financial services, including affordable credit, and
-  their integration into value chains and markets
+target: global_targets.9-3.title
 target_id: '9.3'
-graph_title: Proportion of small-scale industries in total industry value added
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '2'
 ---

--- a/meta/9-3-2.md
+++ b/meta/9-3-2.md
@@ -2,20 +2,18 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)
+graph_title: global_indicators.9-3-2.title
 graph_type: line
 indicator: 9.3.2
-indicator_name: Proportion of small-scale industries with a loan or line of credit
+indicator_name: global_indicators.9-3-2.title
 indicator_sort_order: 09-03-02
 layout: indicator
 permalink: /9-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Increase the access of small-scale industrial and other enterprises, in particular
-  in developing countries, to financial services, including affordable credit, and
-  their integration into value chains and markets
+target: global_targets.9-3.title
 target_id: '9.3'
-graph_title: Proportion of small-scale industries with a loan or line of credit
 un_custodian_agency: UNIDO,World Bank
 un_designated_tier: '2'
 ---

--- a/meta/9-4-1.md
+++ b/meta/9-4-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 516
   KB)
-graph_title: CO2 emission per unit of value added
+graph_title: global_indicators.9-4-1.title
 graph_type: line
 indicator: 9.4.1
-indicator_name: CO2 emission per unit of value added
+indicator_name: global_indicators.9-4-1.title
 indicator_sort_order: 09-04-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,10 +17,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: Armstat, Ministry of Nature Protection of RA
-target: By 2030, upgrade infrastructure and retrofit industries to make them sustainable,
-  with increased resource-use efficiency and greater adoption of clean and environmentally
-  sound technologies and industrial processes, with all countries taking action in
-  accordance with their respective capabilities
+target: global_targets.9-4.title
 target_id: '9.4'
 un_custodian_agency: International Energy Agency (IEA) United Nations Industrial Development
   Organization (UNIDO)

--- a/meta/9-5-1.md
+++ b/meta/9-5-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
   KB)
-graph_title: Research and development expenditure as a proportion of GDP
+graph_title: global_indicators.9-5-1.title
 graph_type: line
 indicator: 9.5.1
-indicator_name: Research and development expenditure as a proportion of GDP
+indicator_name: global_indicators.9-5-1.title
 indicator_sort_order: 09-05-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,10 +17,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: Armstat
-target: Enhance scientific research, upgrade the technological capabilities of industrial
-  sectors in all countries, in particular developing countries, including, by 2030,
-  encouraging innovation and substantially increasing the number of research and development
-  workers per 1 million people and public and private research and development spending
+target: global_targets.9-5.title
 target_id: '9.5'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/9-5-2.md
+++ b/meta/9-5-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
   KB)
-graph_title: Researchers (in full-time equivalent) per million inhabitants
+graph_title: global_indicators.9-5-2.title
 graph_type: line
 indicator: 9.5.2
-indicator_name: Researchers (in full-time equivalent) per million inhabitants
+indicator_name: global_indicators.9-5-2.title
 indicator_sort_order: 09-05-02
 layout: indicator
 national_geographical_coverage: Armenia
@@ -17,10 +17,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: Armstat
-target: Enhance scientific research, upgrade the technological capabilities of industrial
-  sectors in all countries, in particular developing countries, including, by 2030,
-  encouraging innovation and substantially increasing the number of research and development
-  workers per 1 million people and public and private research and development spending
+target: global_targets.9-5.title
 target_id: '9.5'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/9-a-1.md
+++ b/meta/9-a-1.md
@@ -3,25 +3,20 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208
   KB)
+graph_title: global_indicators.9-a-1.title
 graph_type: line
 indicator: 9.a.1
 indicator_definition: Total resource flows for infrastructure, comprising Official
   Development Assistance (ODA), other official flows (OOF) and private flows
-indicator_name: Total official international support (official development assistance
-  plus other official flows) to infrastructure
+indicator_name: global_indicators.9-a-1.title
 indicator_sort_order: 09-aa-01
 layout: indicator
 permalink: /9-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Facilitate sustainable and resilient infrastructure development in developing
-  countries through enhanced financial, technological and technical support to African
-  countries, least developed countries, landlocked developing countries and small
-  island developing States
+target: global_targets.9-a.title
 target_id: 9.a
-graph_title: Total official international support (official development assistance plus
-  other official flows) to infrastructure
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'
 ---

--- a/meta/9-b-1.md
+++ b/meta/9-b-1.md
@@ -3,21 +3,18 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-0B-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 332
   KB)
+graph_title: global_indicators.9-b-1.title
 graph_type: line
 indicator: 9.b.1
-indicator_name: Proportion of medium and high-tech industry value added in total value
-  added
+indicator_name: global_indicators.9-b-1.title
 indicator_sort_order: 09-bb-01
 layout: indicator
 permalink: /9-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: Support domestic technology development, research and innovation in developing
-  countries, including by ensuring a conducive policy environment for, inter alia,
-  industrial diversification and value addition to commodities
+target: global_targets.9-b.title
 target_id: 9.b
-graph_title: Proportion of medium and high-tech industry value added in total value added
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'
 ---

--- a/meta/9-c-1.md
+++ b/meta/9-c-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)
-graph_title: Proportion of population covered by a mobile network, by technology
+graph_title: global_indicators.9-c-1.title
 graph_type: line
 indicator: 9.c.1
-indicator_name: Proportion of population covered by a mobile network, by technology
+indicator_name: global_indicators.9-c-1.title
 indicator_sort_order: 09-cc-01
 layout: indicator
 national_geographical_coverage: Armenia
@@ -16,9 +16,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: Armstat
-target: Significantly increase access to information and communications technology
-  and strive to provide universal and affordable access to the Internet in least developed
-  countries by 2020
+target: global_targets.9-c.title
 target_id: 9.c
 un_custodian_agency: ITU
 un_designated_tier: '1'


### PR DESCRIPTION
This replaces indicator_name, target, and graph_title, in global indicators, with global translation keys.

The script I ran for this also re-formatted some indicator_description entries, but it should be harmless.

NOTE: This depends on this PR: https://github.com/armstat/sdg-site-armenia/pull/60