### PR TITLE
Flatten the global translation keys to match the latest sdg-translations

### DIFF
--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-01-01a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: global_indicators.1-1-1.title
+graph_title: global_indicators.1-1-1-title
 graph_type: line
 indicator: 1.1.1
-indicator_name: global_indicators.1-1-1.title
+indicator_name: global_indicators.1-1-1-title
 indicator_sort_order: 01-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
-target: global_targets.1-1.title
+target: global_targets.1-1-title
 target_id: '1.1'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -4,14 +4,14 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 98.2
   KB)
-graph_title: global_indicators.1-2-1.title
+graph_title: global_indicators.1-2-1-title
 graph_type: line
 indicator: 1.2.1
 indicator_definition: Monitoring national poverty is important for country-specific
   development agendas. National poverty lines are used to make more accurate estimates
   of poverty consistent with the country’s specific economic and social circumstances,
   and are not intended for international comparisons of poverty rates.
-indicator_name: global_indicators.1-2-1.title
+indicator_name: global_indicators.1-2-1-title
 indicator_sort_order: 01-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -23,7 +23,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
-target: global_targets.1-2.title
+target: global_targets.1-2-title
 target_id: '1.2'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/1-2-2.md
+++ b/meta/1-2-2.md
@@ -4,14 +4,14 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 894
   KB)
-graph_title: global_indicators.1-2-2.title
+graph_title: global_indicators.1-2-2-title
 graph_type: line
 indicator: 1.2.2
 indicator_definition: Monitoring national poverty is important for country-specific
   development agendas. National poverty lines are used to make more accurate estimates
   of poverty consistent with the country’s specific economic and social circumstances,
   and are not intended for international comparisons of poverty rates.
-indicator_name: global_indicators.1-2-2.title
+indicator_name: global_indicators.1-2-2-title
 indicator_sort_order: 01-02-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -25,7 +25,7 @@ source_active_3: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
 source_organisation_3: sources.WB
-target: global_targets.1-2.title
+target: global_targets.1-2-title
 target_id: '1.2'
 un_custodian_agency: United Nations Children's Fund (UNICEFF) World Bank (WB) United
   Nations Development Programme (UNDP)

--- a/meta/1-3-1.md
+++ b/meta/1-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-03-01a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: global_indicators.1-3-1.title
+graph_title: global_indicators.1-3-1-title
 graph_type: line
 indicator: 1.3.1
-indicator_name: global_indicators.1-3-1.title
+indicator_name: global_indicators.1-3-1-title
 indicator_sort_order: 01-03-01
 layout: indicator
 permalink: /1-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-3.title
+target: global_targets.1-3-title
 target_id: '1.3'
 un_custodian_agency: ILO
 un_designated_tier: '2'

--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: global_indicators.1-4-1.title
+graph_title: global_indicators.1-4-1-title
 graph_type: line
 indicator: 1.4.1
-indicator_name: global_indicators.1-4-1.title
+indicator_name: global_indicators.1-4-1-title
 indicator_sort_order: 01-04-01
 layout: indicator
 permalink: /1-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-4.title
+target: global_targets.1-4-title
 target_id: '1.4'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'

--- a/meta/1-4-2.md
+++ b/meta/1-4-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: NA
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.1-4-2.title
+graph_title: global_indicators.1-4-2-title
 graph_type: line
 indicator: 1.4.2
-indicator_name: global_indicators.1-4-2.title
+indicator_name: global_indicators.1-4-2-title
 indicator_sort_order: 01-04-02
 layout: indicator
 permalink: /1-4-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-4.title
+target: global_targets.1-4-title
 target_id: '1.4'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '2'

--- a/meta/1-5-1.md
+++ b/meta/1-5-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
   KB)
-graph_title: global_indicators.1-5-1.title
+graph_title: global_indicators.1-5-1-title
 graph_type: line
 indicator: 1.5.1
-indicator_name: global_indicators.1-5-1.title
+indicator_name: global_indicators.1-5-1-title
 indicator_sort_order: 01-05-01
 layout: indicator
 permalink: /1-5-1/
 published: true
 reporting_status: complete
 sdg_goal: '1'
-target: global_targets.1-5.title
+target: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'

--- a/meta/1-5-2.md
+++ b/meta/1-5-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: global_indicators.1-5-2.title
+graph_title: global_indicators.1-5-2-title
 graph_type: line
 indicator: 1.5.2
-indicator_name: global_indicators.1-5-2.title
+indicator_name: global_indicators.1-5-2-title
 indicator_sort_order: 01-05-02
 layout: indicator
 permalink: /1-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-5.title
+target: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/1-5-3.md
+++ b/meta/1-5-3.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: global_indicators.1-5-3.title
+graph_title: global_indicators.1-5-3-title
 graph_type: line
 indicator: 1.5.3
-indicator_name: global_indicators.1-5-3.title
+indicator_name: global_indicators.1-5-3-title
 indicator_sort_order: 01-05-03
 layout: indicator
 permalink: /1-5-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-5.title
+target: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '1'

--- a/meta/1-5-4.md
+++ b/meta/1-5-4.md
@@ -1,17 +1,17 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
-graph_title: global_indicators.1-5-4.title
+graph_title: global_indicators.1-5-4-title
 graph_type: line
 indicator: 1.5.4
-indicator_name: global_indicators.1-5-4.title
+indicator_name: global_indicators.1-5-4-title
 indicator_sort_order: 01-05-04
 layout: indicator
 permalink: /1-5-4/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-5.title
+target: global_targets.1-5-title
 target_id: '1.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/1-a-1.md
+++ b/meta/1-a-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: global_indicators.1-a-1.title
+graph_title: global_indicators.1-a-1-title
 graph_type: line
 indicator: 1.a.1
-indicator_name: global_indicators.1-a-1.title
+indicator_name: global_indicators.1-a-1-title
 indicator_sort_order: 01-aa-01
 layout: indicator
 permalink: /1-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-a.title
+target: global_targets.1-a-title
 target_id: 1.a
 un_designated_tier: '3'
 ---

--- a/meta/1-a-2.md
+++ b/meta/1-a-2.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: TIER III - NO WORK PLAN
-graph_title: global_indicators.1-a-2.title
+graph_title: global_indicators.1-a-2-title
 graph_type: line
 indicator: 1.a.2
-indicator_name: global_indicators.1-a-2.title
+indicator_name: global_indicators.1-a-2-title
 indicator_sort_order: 01-aa-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Finance of RA
-target: global_targets.1-a.title
+target: global_targets.1-a-title
 target_id: 1.a
 un_custodian_agency: Discussions are occurring between the following organisations
   International Labour Organization (ILO) United Nations Educational Scientific and

--- a/meta/1-a-3.md
+++ b/meta/1-a-3.md
@@ -1,17 +1,17 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
-graph_title: global_indicators.1-a-3.title
+graph_title: global_indicators.1-a-3-title
 graph_type: line
 indicator: 1.a.3
-indicator_name: global_indicators.1-a-3.title
+indicator_name: global_indicators.1-a-3-title
 indicator_sort_order: 01-aa-03
 layout: indicator
 permalink: /1-a-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-a.title
+target: global_targets.1-a-title
 target_id: 1.a
 un_designated_tier: '3'
 ---

--- a/meta/1-b-1.md
+++ b/meta/1-b-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
-graph_title: global_indicators.1-b-1.title
+graph_title: global_indicators.1-b-1-title
 graph_type: line
 indicator: 1.b.1
-indicator_name: global_indicators.1-b-1.title
+indicator_name: global_indicators.1-b-1-title
 indicator_sort_order: 01-bb-01
 layout: indicator
 permalink: /1-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '1'
-target: global_targets.1-b.title
+target: global_targets.1-b-title
 target_id: 1.b
 un_designated_tier: '3'
 ---

--- a/meta/10-1-1.md
+++ b/meta/10-1-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 221
   KB)
-graph_title: global_indicators.10-1-1.title
+graph_title: global_indicators.10-1-1-title
 graph_type: line
 indicator: 10.1.1
-indicator_name: global_indicators.10-1-1.title
+indicator_name: global_indicators.10-1-1-title
 indicator_sort_order: 10-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -21,7 +21,7 @@ source_active_3: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
 source_organisation_3: sources.WB
-target: global_targets.10-1.title
+target: global_targets.10-1-title
 target_id: '10.1'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: 2

--- a/meta/10-2-1.md
+++ b/meta/10-2-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.10-2-1.title
+graph_title: global_indicators.10-2-1-title
 graph_type: line
 indicator: 10.2.1
 indicator_definition: This indicator is a measure of relative income poverty at the
@@ -13,14 +13,14 @@ indicator_definition: This indicator is a measure of relative income poverty at 
   unemployment, poor housing, inadequate health care and barriers in accessing education
   and economic, social, political and cultural activities, which can result from social
   stigmatisation.
-indicator_name: global_indicators.10-2-1.title
+indicator_name: global_indicators.10-2-1-title
 indicator_sort_order: 10-02-01
 layout: indicator
 permalink: /10-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-2.title
+target: global_targets.10-2-title
 target_id: '10.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF) World Bank (WB)
 un_designated_tier: '3'

--- a/meta/10-3-1.md
+++ b/meta/10-3-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.10-3-1.title
+graph_title: global_indicators.10-3-1-title
 graph_type: line
 indicator: 10.3.1
-indicator_name: global_indicators.10-3-1.title
+indicator_name: global_indicators.10-3-1-title
 indicator_sort_order: 10-03-01
 layout: indicator
 permalink: /10-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-3.title
+target: global_targets.10-3-title
 target_id: '10.3'
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/10-4-1.md
+++ b/meta/10-4-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 190
   KB)
-graph_title: global_indicators.10-4-1.title
+graph_title: global_indicators.10-4-1-title
 graph_type: line
 indicator: 10.4.1
-indicator_name: global_indicators.10-4-1.title
+indicator_name: global_indicators.10-4-1-title
 indicator_sort_order: 10-04-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '10'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.10-4.title
+target: global_targets.10-4-title
 target_id: '10.4'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '2'

--- a/meta/10-5-1.md
+++ b/meta/10-5-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
-graph_title: global_indicators.10-5-1.title
+graph_title: global_indicators.10-5-1-title
 graph_type: line
 indicator: 10.5.1
-indicator_name: global_indicators.10-5-1.title
+indicator_name: global_indicators.10-5-1-title
 indicator_sort_order: 10-05-01
 layout: indicator
 permalink: /10-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-5.title
+target: global_targets.10-5-title
 target_id: '10.5'
 un_custodian_agency: IMF
 un_designated_tier: '3'

--- a/meta/10-6-1.md
+++ b/meta/10-6-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 201
   KB)
-graph_title: global_indicators.10-6-1.title
+graph_title: global_indicators.10-6-1-title
 graph_type: line
 indicator: 10.6.1
-indicator_name: global_indicators.10-6-1.title
+indicator_name: global_indicators.10-6-1-title
 indicator_sort_order: 10-06-01
 layout: indicator
 permalink: /10-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-6.title
+target: global_targets.10-6-title
 target_id: '10.6'
 un_custodian_agency: United Nations Department of Economic and Social Affairs (DESA)
   / Financing for Development Office (FFDO)

--- a/meta/10-7-1.md
+++ b/meta/10-7-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
-graph_title: global_indicators.10-7-1.title
+graph_title: global_indicators.10-7-1-title
 graph_type: line
 indicator: 10.7.1
-indicator_name: global_indicators.10-7-1.title
+indicator_name: global_indicators.10-7-1-title
 indicator_sort_order: 10-07-01
 layout: indicator
 permalink: /10-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-7.title
+target: global_targets.10-7-title
 target_id: '10.7'
 un_custodian_agency: ILO,World Bank
 un_designated_tier: '3'

--- a/meta/10-7-2.md
+++ b/meta/10-7-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
-graph_title: global_indicators.10-7-2.title
+graph_title: global_indicators.10-7-2-title
 graph_type: line
 indicator: 10.7.2
-indicator_name: global_indicators.10-7-2.title
+indicator_name: global_indicators.10-7-2-title
 indicator_sort_order: 10-07-02
 layout: indicator
 permalink: /10-7-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-7.title
+target: global_targets.10-7-title
 target_id: '10.7'
 un_custodian_agency: DESA Population Division,IOM
 un_designated_tier: '3'

--- a/meta/10-a-1.md
+++ b/meta/10-a-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
-graph_title: global_indicators.10-a-1.title
+graph_title: global_indicators.10-a-1-title
 graph_type: line
 indicator: 10.a.1
-indicator_name: global_indicators.10-a-1.title
+indicator_name: global_indicators.10-a-1-title
 indicator_sort_order: 10-aa-01
 layout: indicator
 permalink: /10-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-a.title
+target: global_targets.10-a-title
 target_id: 10.a
 un_custodian_agency: ITC,UNCTAD,WTO
 un_designated_tier: '1'

--- a/meta/10-b-1.md
+++ b/meta/10-b-1.md
@@ -3,20 +3,20 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-10-0B-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 202
   KB)
-graph_title: global_indicators.10-b-1.title
+graph_title: global_indicators.10-b-1-title
 graph_type: line
 indicator: 10.b.1
 indicator_definition: Total resource flows for development, by recipient and donor
   countries and type of flow comprises of Official Development Assistance (ODA), other
   official flows (OOF) and private flows.
-indicator_name: global_indicators.10-b-1.title
+indicator_name: global_indicators.10-b-1-title
 indicator_sort_order: 10-bb-01
 layout: indicator
 permalink: /10-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-b.title
+target: global_targets.10-b-title
 target_id: 10.b
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1 (ODA) / 2 (FDI)

--- a/meta/10-c-1.md
+++ b/meta/10-c-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
-graph_title: global_indicators.10-c-1.title
+graph_title: global_indicators.10-c-1-title
 graph_type: line
 indicator: 10.c.1
-indicator_name: global_indicators.10-c-1.title
+indicator_name: global_indicators.10-c-1-title
 indicator_sort_order: 10-cc-01
 layout: indicator
 permalink: /10-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '10'
-target: global_targets.10-c.title
+target: global_targets.10-c-title
 target_id: 10.c
 un_custodian_agency: World Bank
 un_designated_tier: '2'

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 93.1
   KB)
-graph_title: global_indicators.11-1-1.title
+graph_title: global_indicators.11-1-1-title
 graph_type: line
 indicator: 11.1.1
-indicator_name: global_indicators.11-1-1.title
+indicator_name: global_indicators.11-1-1-title
 indicator_sort_order: 11-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Population Census
-target: global_targets.11-1.title
+target: global_targets.11-1-title
 target_id: '11.1'
 un_custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
 un_designated_tier: '1'

--- a/meta/11-2-1.md
+++ b/meta/11-2-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-2-1.title
+graph_title: global_indicators.11-2-1-title
 graph_type: line
 indicator: 11.2.1
-indicator_name: global_indicators.11-2-1.title
+indicator_name: global_indicators.11-2-1-title
 indicator_sort_order: 11-02-01
 layout: indicator
 permalink: /11-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-2.title
+target: global_targets.11-2-title
 target_id: '11.2'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '2'

--- a/meta/11-3-1.md
+++ b/meta/11-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-3-1.title
+graph_title: global_indicators.11-3-1-title
 graph_type: line
 indicator: 11.3.1
-indicator_name: global_indicators.11-3-1.title
+indicator_name: global_indicators.11-3-1-title
 indicator_sort_order: 11-03-01
 layout: indicator
 permalink: /11-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-3.title
+target: global_targets.11-3-title
 target_id: '11.3'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '2'

--- a/meta/11-3-2.md
+++ b/meta/11-3-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-3-2.title
+graph_title: global_indicators.11-3-2-title
 graph_type: line
 indicator: 11.3.2
-indicator_name: global_indicators.11-3-2.title
+indicator_name: global_indicators.11-3-2-title
 indicator_sort_order: 11-03-02
 layout: indicator
 permalink: /11-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-3.title
+target: global_targets.11-3-title
 target_id: '11.3'
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'

--- a/meta/11-4-1.md
+++ b/meta/11-4-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.11-4-1.title
+graph_title: global_indicators.11-4-1-title
 graph_type: line
 indicator: 11.4.1
-indicator_name: global_indicators.11-4-1.title
+indicator_name: global_indicators.11-4-1-title
 indicator_sort_order: 11-04-01
 layout: indicator
 permalink: /11-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-4.title
+target: global_targets.11-4-title
 target_id: '11.4'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/11-5-1.md
+++ b/meta/11-5-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
   KB)
-graph_title: global_indicators.11-5-1.title
+graph_title: global_indicators.11-5-1-title
 graph_type: line
 indicator: 11.5.1
-indicator_name: global_indicators.11-5-1.title
+indicator_name: global_indicators.11-5-1-title
 indicator_sort_order: 11-05-01
 layout: indicator
 permalink: /11-5-1/
 published: true
 reporting_status: complete
 sdg_goal: '11'
-target: global_targets.11-5.title
+target: global_targets.11-5-title
 target_id: '11.5'
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'

--- a/meta/11-5-2.md
+++ b/meta/11-5-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-5-2.title
+graph_title: global_indicators.11-5-2-title
 graph_type: line
 indicator: 11.5.2
-indicator_name: global_indicators.11-5-2.title
+indicator_name: global_indicators.11-5-2-title
 indicator_sort_order: 11-05-02
 layout: indicator
 permalink: /11-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-5.title
+target: global_targets.11-5-title
 target_id: '11.5'
 un_custodian_agency: UNISDR
 un_designated_tier: '1'

--- a/meta/11-6-1.md
+++ b/meta/11-6-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-6-1.title
+graph_title: global_indicators.11-6-1-title
 graph_type: line
 indicator: 11.6.1
-indicator_name: global_indicators.11-6-1.title
+indicator_name: global_indicators.11-6-1-title
 indicator_sort_order: 11-06-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Nature Protection of RA
-target: global_targets.11-6.title
+target: global_targets.11-6-title
 target_id: '11.6'
 un_custodian_agency: UN-Habitat,UNSD
 un_designated_tier: '2'

--- a/meta/11-6-2.md
+++ b/meta/11-6-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
-graph_title: global_indicators.11-6-2.title
+graph_title: global_indicators.11-6-2-title
 graph_type: line
 indicator: 11.6.2
-indicator_name: global_indicators.11-6-2.title
+indicator_name: global_indicators.11-6-2-title
 indicator_sort_order: 11-06-02
 layout: indicator
 permalink: /11-6-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-6.title
+target: global_targets.11-6-title
 target_id: '11.6'
 un_custodian_agency: World Health Organization (WHO)
 un_designated_tier: '1'

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-7-1.title
+graph_title: global_indicators.11-7-1-title
 graph_type: line
 indicator: 11.7.1
-indicator_name: global_indicators.11-7-1.title
+indicator_name: global_indicators.11-7-1-title
 indicator_sort_order: 11-07-01
 layout: indicator
 permalink: /11-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-7.title
+target: global_targets.11-7-title
 target_id: '11.7'
 un_custodian_agency: United Nations Human Settlements Programme (UN-Habitat)
 un_designated_tier: '2'

--- a/meta/11-7-2.md
+++ b/meta/11-7-2.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.11-7-2.title
+graph_title: global_indicators.11-7-2-title
 graph_type: line
 indicator: 11.7.2
 indicator_definition: Proportion of persons victim of physical or sexual harassment,
   by sex, age, disability status and place of occurrence, in the previous 12 months
-indicator_name: global_indicators.11-7-2.title
+indicator_name: global_indicators.11-7-2-title
 indicator_sort_order: 11-07-02
 layout: indicator
 permalink: /11-7-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-7.title
+target: global_targets.11-7-title
 target_id: '11.7'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '3'

--- a/meta/11-a-1.md
+++ b/meta/11-a-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-a-1.title
+graph_title: global_indicators.11-a-1-title
 graph_type: line
 indicator: 11.a.1
-indicator_name: global_indicators.11-a-1.title
+indicator_name: global_indicators.11-a-1-title
 indicator_sort_order: 11-aa-01
 layout: indicator
 permalink: /11-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-a.title
+target: global_targets.11-a-title
 target_id: 11.a
 un_custodian_agency: UN-Habitat
 un_designated_tier: '3'

--- a/meta/11-b-1.md
+++ b/meta/11-b-1.md
@@ -3,10 +3,10 @@ computation_units: data.yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-b-1.title
+graph_title: global_indicators.11-b-1-title
 graph_type: line
 indicator: 11.b.1
-indicator_name: global_indicators.11-b-1.title
+indicator_name: global_indicators.11-b-1-title
 indicator_sort_order: 11-bb-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '11'
 source_active_1: true
 source_organisation_1: sources.Ministry of Emergency situations of RA
-target: global_targets.11-b.title
+target: global_targets.11-b-title
 target_id: 11.b
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/11-b-2.md
+++ b/meta/11-b-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
-graph_title: global_indicators.11-b-2.title
+graph_title: global_indicators.11-b-2-title
 graph_type: line
 indicator: 11.b.2
-indicator_name: global_indicators.11-b-2.title
+indicator_name: global_indicators.11-b-2-title
 indicator_sort_order: 11-bb-02
 layout: indicator
 permalink: /11-b-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-b.title
+target: global_targets.11-b-title
 target_id: 11.b
 un_custodian_agency: UNISDR
 un_designated_tier: '3'

--- a/meta/11-c-1.md
+++ b/meta/11-c-1.md
@@ -3,20 +3,20 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/?Text=&Goal=11&Target= '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.11-c-1.title
+graph_title: global_indicators.11-c-1-title
 graph_type: line
 indicator: 11.c.1
 indicator_definition: Proportion of financial support to the least developed countries
   that is allocated to the construction and retrofitting of sustainable, resilient
   and resource-efficient buildings utilizing local materials.
-indicator_name: global_indicators.11-c-1.title
+indicator_name: global_indicators.11-c-1-title
 indicator_sort_order: 11-cc-01
 layout: indicator
 permalink: /11-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '11'
-target: global_targets.11-c.title
+target: global_targets.11-c-title
 target_id: 11.c
 un_custodian_agency:  Organisation for Economic Co-operation and Development (OECD)
   United Nations Environment (UNEP) World Bank (WB)

--- a/meta/12-1-1.md
+++ b/meta/12-1-1.md
@@ -3,10 +3,10 @@ computation_units: data.yes=1, no=0
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-1-1.title
+graph_title: global_indicators.12-1-1-title
 graph_type: line
 indicator: 12.1.1
-indicator_name: global_indicators.12-1-1.title
+indicator_name: global_indicators.12-1-1-title
 indicator_sort_order: 12-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -14,7 +14,7 @@ permalink: /12-1-1/
 published: true
 reporting_status: complete
 sdg_goal: '12'
-target: global_targets.12-1.title
+target: global_targets.12-1-title
 target_id: '12.1'
 un_custodian_agency: UNEP
 un_designated_tier: '2'

--- a/meta/12-2-1.md
+++ b/meta/12-2-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.12-2-1.title
+graph_title: global_indicators.12-2-1-title
 graph_type: line
 indicator: 12.2.1
-indicator_name: global_indicators.12-2-1.title
+indicator_name: global_indicators.12-2-1-title
 indicator_sort_order: 12-02-01
 layout: indicator
 permalink: /12-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-2.title
+target: global_targets.12-2-title
 target_id: '12.2'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '3'

--- a/meta/12-2-2.md
+++ b/meta/12-2-2.md
@@ -3,10 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 783
   KB)
-graph_title: global_indicators.12-2-2.title
+graph_title: global_indicators.12-2-2-title
 graph_type: line
 indicator: 12.2.2
-indicator_name: global_indicators.12-2-2.title
+indicator_name: global_indicators.12-2-2-title
 indicator_sort_order: 12-02-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '12'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.12-2.title
+target: global_targets.12-2-title
 target_id: '12.2'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '2'

--- a/meta/12-3-1.md
+++ b/meta/12-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-3-1.title
+graph_title: global_indicators.12-3-1-title
 graph_type: line
 indicator: 12.3.1
-indicator_name: global_indicators.12-3-1.title
+indicator_name: global_indicators.12-3-1-title
 indicator_sort_order: 12-03-01
 layout: indicator
 permalink: /12-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-3.title
+target: global_targets.12-3-title
 target_id: '12.3'
 un_custodian_agency: FAO, UNEP
 un_designated_tier: '3'

--- a/meta/12-4-1.md
+++ b/meta/12-4-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-12-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-4-1.title
+graph_title: global_indicators.12-4-1-title
 graph_type: line
 indicator: 12.4.1
-indicator_name: global_indicators.12-4-1.title
+indicator_name: global_indicators.12-4-1-title
 indicator_sort_order: 12-04-01
 layout: indicator
 permalink: /12-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-4.title
+target: global_targets.12-4-title
 target_id: '12.4'
 un_custodian_agency: UNEP
 un_designated_tier: '1'

--- a/meta/12-4-2.md
+++ b/meta/12-4-2.md
@@ -3,10 +3,10 @@ computation_units: data.kg per capita
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-4-2.title
+graph_title: global_indicators.12-4-2-title
 graph_type: line
 indicator: 12.4.2
-indicator_name: global_indicators.12-4-2.title
+indicator_name: global_indicators.12-4-2-title
 indicator_sort_order: 12-04-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Nature Protection of RA
-target: global_targets.12-4.title
+target: global_targets.12-4-title
 target_id: '12.4'
 un_custodian_agency: UNSD, UNEP
 un_designated_tier: '3'

--- a/meta/12-5-1.md
+++ b/meta/12-5-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-5-1.title
+graph_title: global_indicators.12-5-1-title
 graph_type: line
 indicator: 12.5.1
-indicator_name: global_indicators.12-5-1.title
+indicator_name: global_indicators.12-5-1-title
 indicator_sort_order: 12-05-01
 layout: indicator
 permalink: /12-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-5.title
+target: global_targets.12-5-title
 target_id: '12.5'
 un_custodian_agency: United Nations Statistics Division (UNSD), UN Environment (UNEP)
 un_designated_tier: '3'

--- a/meta/12-6-1.md
+++ b/meta/12-6-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-6-1.title
+graph_title: global_indicators.12-6-1-title
 graph_type: line
 indicator: 12.6.1
-indicator_name: global_indicators.12-6-1.title
+indicator_name: global_indicators.12-6-1-title
 indicator_sort_order: 12-06-01
 layout: indicator
 permalink: /12-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-6.title
+target: global_targets.12-6-title
 target_id: '12.6'
 un_custodian_agency: UNEP,  UNCTAD
 un_designated_tier: '3'

--- a/meta/12-7-1.md
+++ b/meta/12-7-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-7-1.title
+graph_title: global_indicators.12-7-1-title
 graph_type: line
 indicator: 12.7.1
-indicator_name: global_indicators.12-7-1.title
+indicator_name: global_indicators.12-7-1-title
 indicator_sort_order: 12-07-01
 layout: indicator
 permalink: /12-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-7.title
+target: global_targets.12-7-title
 target_id: '12.7'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/12-8-1.md
+++ b/meta/12-8-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-8-1.title
+graph_title: global_indicators.12-8-1-title
 graph_type: line
 indicator: 12.8.1
-indicator_name: global_indicators.12-8-1.title
+indicator_name: global_indicators.12-8-1-title
 indicator_sort_order: 12-08-01
 layout: indicator
 permalink: /12-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-8.title
+target: global_targets.12-8-title
 target_id: '12.8'
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/12-a-1.md
+++ b/meta/12-a-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-a-1.title
+graph_title: global_indicators.12-a-1-title
 graph_type: line
 indicator: 12.a.1
-indicator_name: global_indicators.12-a-1.title
+indicator_name: global_indicators.12-a-1-title
 indicator_sort_order: 12-aa-01
 layout: indicator
 permalink: /12-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-a.title
+target: global_targets.12-a-title
 target_id: 12.a
 un_custodian_agency: Under discussion among agencies (OECD, UNEP,UNESCO-UIS,World
   Bank)

--- a/meta/12-b-1.md
+++ b/meta/12-b-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-b-1.title
+graph_title: global_indicators.12-b-1-title
 graph_type: line
 indicator: 12.b.1
-indicator_name: global_indicators.12-b-1.title
+indicator_name: global_indicators.12-b-1-title
 indicator_sort_order: 12-bb-01
 layout: indicator
 permalink: /12-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-b.title
+target: global_targets.12-b-title
 target_id: 12.b
 un_custodian_agency: UNWTO
 un_designated_tier: '3'

--- a/meta/12-c-1.md
+++ b/meta/12-c-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
-graph_title: global_indicators.12-c-1.title
+graph_title: global_indicators.12-c-1-title
 graph_type: line
 indicator: 12.c.1
-indicator_name: global_indicators.12-c-1.title
+indicator_name: global_indicators.12-c-1-title
 indicator_sort_order: 12-cc-01
 layout: indicator
 permalink: /12-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '12'
-target: global_targets.12-c.title
+target: global_targets.12-c-title
 target_id: 12.c
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
   KB)
-graph_title: global_indicators.13-1-1.title
+graph_title: global_indicators.13-1-1-title
 graph_type: line
 indicator: 13.1.1
-indicator_name: global_indicators.13-1-1.title
+indicator_name: global_indicators.13-1-1-title
 indicator_sort_order: 13-01-01
 layout: indicator
 permalink: /13-1-1/
 published: true
 reporting_status: complete
 sdg_goal: '13'
-target: global_targets.13-1.title
+target: global_targets.13-1-title
 target_id: '13.1'
 un_custodian_agency: United Nations Office for Disaster Reduction (UNISDR)
 un_designated_tier: '2'

--- a/meta/13-1-2.md
+++ b/meta/13-1-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
-graph_title: global_indicators.13-1-2.title
+graph_title: global_indicators.13-1-2-title
 graph_type: line
 indicator: 13.1.2
-indicator_name: global_indicators.13-1-2.title
+indicator_name: global_indicators.13-1-2-title
 indicator_sort_order: 13-01-02
 layout: indicator
 permalink: /13-1-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: global_targets.13-1.title
+target: global_targets.13-1-title
 target_id: '13.1'
 un_custodian_agency: UNISDR
 un_designated_tier: '2'

--- a/meta/13-1-3.md
+++ b/meta/13-1-3.md
@@ -1,17 +1,17 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
-graph_title: global_indicators.13-1-3.title
+graph_title: global_indicators.13-1-3-title
 graph_type: line
 indicator: 13.1.3
-indicator_name: global_indicators.13-1-3.title
+indicator_name: global_indicators.13-1-3-title
 indicator_sort_order: 13-01-03
 layout: indicator
 permalink: /13-1-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: global_targets.13-1.title
+target: global_targets.13-1-title
 target_id: '13.1'
 un_custodian_agency: UNISDR
 un_designated_tier: '3'

--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
-graph_title: global_indicators.13-2-1.title
+graph_title: global_indicators.13-2-1-title
 graph_type: line
 indicator: 13.2.1
-indicator_name: global_indicators.13-2-1.title
+indicator_name: global_indicators.13-2-1-title
 indicator_sort_order: 13-02-01
 layout: indicator
 permalink: /13-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: global_targets.13-2.title
+target: global_targets.13-2-title
 target_id: '13.2'
 un_custodian_agency: UNFCCC
 un_designated_tier: '3'

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
-graph_title: global_indicators.13-3-1.title
+graph_title: global_indicators.13-3-1-title
 graph_type: line
 indicator: 13.3.1
-indicator_name: global_indicators.13-3-1.title
+indicator_name: global_indicators.13-3-1-title
 indicator_sort_order: 13-03-01
 layout: indicator
 permalink: /13-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: global_targets.13-3.title
+target: global_targets.13-3-title
 target_id: '13.3'
 un_custodian_agency: UNFCCC,UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/13-3-2.md
+++ b/meta/13-3-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
-graph_title: global_indicators.13-3-2.title
+graph_title: global_indicators.13-3-2-title
 graph_type: line
 indicator: 13.3.2
-indicator_name: global_indicators.13-3-2.title
+indicator_name: global_indicators.13-3-2-title
 indicator_sort_order: 13-03-02
 layout: indicator
 permalink: /13-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: global_targets.13-3.title
+target: global_targets.13-3-title
 target_id: '13.3'
 un_custodian_agency: UNFCCC,UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/13-a-1.md
+++ b/meta/13-a-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
-graph_title: global_indicators.13-a-1.title
+graph_title: global_indicators.13-a-1-title
 graph_type: line
 indicator: 13.a.1
-indicator_name: global_indicators.13-a-1.title
+indicator_name: global_indicators.13-a-1-title
 indicator_sort_order: 13-aa-01
 layout: indicator
 permalink: /13-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: global_targets.13-a.title
+target: global_targets.13-a-title
 target_id: 13.a
 un_custodian_agency: UNFCCC,OECD
 un_designated_tier: '3'

--- a/meta/13-b-1.md
+++ b/meta/13-b-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
-graph_title: global_indicators.13-b-1.title
+graph_title: global_indicators.13-b-1-title
 graph_type: line
 indicator: 13.b.1
-indicator_name: global_indicators.13-b-1.title
+indicator_name: global_indicators.13-b-1-title
 indicator_sort_order: 13-bb-01
 layout: indicator
 permalink: /13-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '13'
-target: global_targets.13-b.title
+target: global_targets.13-b-title
 target_id: 13.b
 un_custodian_agency: OHRLLS, Regional Commissions, AOSIS, SIDS, Samoa Pathway
 un_designated_tier: '3'

--- a/meta/14-1-1.md
+++ b/meta/14-1-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
-graph_title: global_indicators.14-1-1.title
+graph_title: global_indicators.14-1-1-title
 graph_type: line
 indicator: 14.1.1
-indicator_name: global_indicators.14-1-1.title
+indicator_name: global_indicators.14-1-1-title
 indicator_sort_order: 14-01-01
 layout: indicator
 permalink: /14-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-1.title
+target: global_targets.14-1-title
 target_id: '14.1'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288
   kB)
-graph_title: global_indicators.14-2-1.title
+graph_title: global_indicators.14-2-1-title
 graph_type: line
 indicator: 14.2.1
-indicator_name: global_indicators.14-2-1.title
+indicator_name: global_indicators.14-2-1-title
 indicator_sort_order: 14-02-01
 layout: indicator
 permalink: /14-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-2.title
+target: global_targets.14-2-title
 target_id: '14.2'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/14-3-1.md
+++ b/meta/14-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
-graph_title: global_indicators.14-3-1.title
+graph_title: global_indicators.14-3-1-title
 graph_type: line
 indicator: 14.3.1
-indicator_name: global_indicators.14-3-1.title
+indicator_name: global_indicators.14-3-1-title
 indicator_sort_order: 14-03-01
 layout: indicator
 permalink: /14-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-3.title
+target: global_targets.14-3-title
 target_id: '14.3'
 un_custodian_agency: 'IOC-UNESCO '
 un_designated_tier: '3'

--- a/meta/14-4-1.md
+++ b/meta/14-4-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 370
   KB)
-graph_title: global_indicators.14-4-1.title
+graph_title: global_indicators.14-4-1-title
 graph_type: line
 indicator: 14.4.1
 indicator_definition: The indicator Proportion of fish stocks within biologically
@@ -12,14 +12,14 @@ indicator_definition: The indicator Proportion of fish stocks within biologicall
   that can produce the maximum sustainable yield (MSY) is classified as biologically
   sustainable. In contrast, when abundance falls below the MSY level, the stock is
   considered biologically unsustainable.
-indicator_name: global_indicators.14-4-1.title
+indicator_name: global_indicators.14-4-1-title
 indicator_sort_order: 14-04-01
 layout: indicator
 permalink: /14-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-4.title
+target: global_targets.14-4-title
 target_id: '14.4'
 un_custodian_agency: Food and Agriculture Organization of the United Nations (FAO)
 un_designated_tier: '1'

--- a/meta/14-5-1.md
+++ b/meta/14-5-1.md
@@ -3,21 +3,21 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 293
   KB)
-graph_title: global_indicators.14-5-1.title
+graph_title: global_indicators.14-5-1-title
 graph_type: line
 indicator: 14.5.1
 indicator_definition: The indicator Coverage of protected areas in relation to marine
   areas shows temporal trends in the mean percentage of each important site for marine
   biodiversity (i.e., those that contribute significantly to the global persistence
   of biodiversity) that is covered by designated protected areas.
-indicator_name: global_indicators.14-5-1.title
+indicator_name: global_indicators.14-5-1-title
 indicator_sort_order: 14-05-01
 layout: indicator
 permalink: /14-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-5.title
+target: global_targets.14-5-title
 target_id: '14.5'
 un_custodian_agency: UN Environment World Conservation Monitoring Centre (UNEP-WCMC)
   BirdLife International (BLI) International Union for Conservation of Nature (IUCN)

--- a/meta/14-6-1.md
+++ b/meta/14-6-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
-graph_title: global_indicators.14-6-1.title
+graph_title: global_indicators.14-6-1-title
 graph_type: line
 indicator: 14.6.1
-indicator_name: global_indicators.14-6-1.title
+indicator_name: global_indicators.14-6-1-title
 indicator_sort_order: 14-06-01
 layout: indicator
 permalink: /14-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-6.title
+target: global_targets.14-6-title
 target_id: '14.6'
 un_custodian_agency: FAO
 un_designated_tier: '3'

--- a/meta/14-7-1.md
+++ b/meta/14-7-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
-graph_title: global_indicators.14-7-1.title
+graph_title: global_indicators.14-7-1-title
 graph_type: line
 indicator: 14.7.1
-indicator_name: global_indicators.14-7-1.title
+indicator_name: global_indicators.14-7-1-title
 indicator_sort_order: 14-07-01
 layout: indicator
 permalink: /14-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-7.title
+target: global_targets.14-7-title
 target_id: '14.7'
 un_custodian_agency: FAO,UNEP-WCMC
 un_designated_tier: '3'

--- a/meta/14-a-1.md
+++ b/meta/14-a-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
-graph_title: global_indicators.14-a-1.title
+graph_title: global_indicators.14-a-1-title
 graph_type: line
 indicator: 14.a.1
-indicator_name: global_indicators.14-a-1.title
+indicator_name: global_indicators.14-a-1-title
 indicator_sort_order: 14-aa-01
 layout: indicator
 permalink: /14-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-a.title
+target: global_targets.14-a-title
 target_id: 14.a
 un_custodian_agency: IOC-UNESCO
 un_designated_tier: '2'

--- a/meta/14-b-1.md
+++ b/meta/14-b-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
-graph_title: global_indicators.14-b-1.title
+graph_title: global_indicators.14-b-1-title
 graph_type: line
 indicator: 14.b.1
-indicator_name: global_indicators.14-b-1.title
+indicator_name: global_indicators.14-b-1-title
 indicator_sort_order: 14-bb-01
 layout: indicator
 permalink: /14-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-b.title
+target: global_targets.14-b-title
 target_id: 14.b
 un_custodian_agency: FAO
 un_designated_tier: '3'

--- a/meta/14-c-1.md
+++ b/meta/14-c-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
-graph_title: global_indicators.14-c-1.title
+graph_title: global_indicators.14-c-1-title
 graph_type: line
 indicator: 14.c.1
-indicator_name: global_indicators.14-c-1.title
+indicator_name: global_indicators.14-c-1-title
 indicator_sort_order: 14-cc-01
 layout: indicator
 permalink: /14-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '14'
-target: global_targets.14-c.title
+target: global_targets.14-c-title
 target_id: 14.c
 un_custodian_agency: UN-DOALOS,FAO,UNEP,ILO,other UN-Oceans agencies
 un_designated_tier: '3'

--- a/meta/15-1-1.md
+++ b/meta/15-1-1.md
@@ -4,11 +4,11 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 379
   KB)
-graph_title: global_indicators.15-1-1.title
+graph_title: global_indicators.15-1-1-title
 graph_type: line
 indicator: 15.1.1
 indicator_definition: Forest area as a proportion of total land area
-indicator_name: global_indicators.15-1-1.title
+indicator_name: global_indicators.15-1-1-title
 indicator_sort_order: 15-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -20,7 +20,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Nature Protection of RA
-target: global_targets.15.title
+target: global_targets.15-title
 target_id: '15'
 un_custodian_agency: Food and Agricultural Organization
 un_designated_tier: '1'

--- a/meta/15-1-2.md
+++ b/meta/15-1-2.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: global_indicators.15-1-2.title
+graph_title: global_indicators.15-1-2-title
 graph_type: line
 indicator: 15.1.2
-indicator_name: global_indicators.15-1-2.title
+indicator_name: global_indicators.15-1-2-title
 indicator_sort_order: 15-01-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Nature Protection of RA
-target: global_targets.15-1.title
+target: global_targets.15-1-title
 target_id: '15.1'
 un_custodian_agency: UNEP-WCMC,UNEP
 un_designated_tier: '1'

--- a/meta/15-2-1.md
+++ b/meta/15-2-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-15-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 756
   KB)
-graph_title: global_indicators.15-2-1.title
+graph_title: global_indicators.15-2-1-title
 graph_type: line
 indicator: 15.2.1
-indicator_name: global_indicators.15-2-1.title
+indicator_name: global_indicators.15-2-1-title
 indicator_sort_order: 15-02-01
 layout: indicator
 permalink: /15-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-2.title
+target: global_targets.15-2-title
 target_id: '15.2'
 un_custodian_agency: Food and Agriculture Organisation of the United Nations (FAO)
 un_designated_tier: '1'

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: global_indicators.15-3-1.title
+graph_title: global_indicators.15-3-1-title
 graph_type: line
 indicator: 15.3.1
-indicator_name: global_indicators.15-3-1.title
+indicator_name: global_indicators.15-3-1-title
 indicator_sort_order: 15-03-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -22,7 +22,7 @@ source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Agriculture of RA
 source_organisation_3: sources.Ministry of Nature Protection of RA
 source_organisation_4: sources.National Academy of Sciences of RA
-target: global_targets.15-3.title
+target: global_targets.15-3-title
 target_id: '15.3'
 un_custodian_agency: UNCCD
 un_designated_tier: '3'

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: global_indicators.15-4-1.title
+graph_title: global_indicators.15-4-1-title
 graph_type: line
 indicator: 15.4.1
-indicator_name: global_indicators.15-4-1.title
+indicator_name: global_indicators.15-4-1-title
 indicator_sort_order: 15-04-01
 layout: indicator
 permalink: /15-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-4.title
+target: global_targets.15-4-title
 target_id: '15.4'
 un_custodian_agency: UNEP-WCMC,UNEP
 un_designated_tier: '1'

--- a/meta/15-4-2.md
+++ b/meta/15-4-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 384
   KB)
-graph_title: global_indicators.15-4-2.title
+graph_title: global_indicators.15-4-2-title
 graph_type: line
 indicator: 15.4.2
-indicator_name: global_indicators.15-4-2.title
+indicator_name: global_indicators.15-4-2-title
 indicator_sort_order: 15-04-02
 layout: indicator
 permalink: /15-4-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-4.title
+target: global_targets.15-4-title
 target_id: '15.4'
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '1'

--- a/meta/15-5-1.md
+++ b/meta/15-5-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 440
   KB)
-graph_title: global_indicators.15-5-1.title
+graph_title: global_indicators.15-5-1-title
 graph_type: line
 indicator: 15.5.1
-indicator_name: global_indicators.15-5-1.title
+indicator_name: global_indicators.15-5-1-title
 indicator_sort_order: 15-05-01
 layout: indicator
 permalink: /15-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-5.title
+target: global_targets.15-5-title
 target_id: '15.5'
 un_custodian_agency: International Union for Conservation of Nature (IUCN) BirdLife
   International (BLI)

--- a/meta/15-6-1.md
+++ b/meta/15-6-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: global_indicators.15-6-1.title
+graph_title: global_indicators.15-6-1-title
 graph_type: line
 indicator: 15.6.1
-indicator_name: global_indicators.15-6-1.title
+indicator_name: global_indicators.15-6-1-title
 indicator_sort_order: 15-06-01
 layout: indicator
 permalink: /15-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-6.title
+target: global_targets.15-6-title
 target_id: '15.6'
 un_custodian_agency: CBD-Secretariat
 un_designated_tier: '1'

--- a/meta/15-7-1.md
+++ b/meta/15-7-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
-graph_title: global_indicators.15-7-1.title
+graph_title: global_indicators.15-7-1-title
 graph_type: line
 indicator: 15.7.1
-indicator_name: global_indicators.15-7-1.title
+indicator_name: global_indicators.15-7-1-title
 indicator_sort_order: 15-07-01
 layout: indicator
 permalink: /15-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-7.title
+target: global_targets.15-7-title
 target_id: '15.7'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '2'

--- a/meta/15-8-1.md
+++ b/meta/15-8-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: global_indicators.15-8-1.title
+graph_title: global_indicators.15-8-1-title
 graph_type: line
 indicator: 15.8.1
-indicator_name: global_indicators.15-8-1.title
+indicator_name: global_indicators.15-8-1-title
 indicator_sort_order: 15-08-01
 layout: indicator
 permalink: /15-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-8.title
+target: global_targets.15-8-title
 target_id: '15.8'
 un_custodian_agency: IUCN
 un_designated_tier: '2'

--- a/meta/15-9-1.md
+++ b/meta/15-9-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
-graph_title: global_indicators.15-9-1.title
+graph_title: global_indicators.15-9-1-title
 graph_type: line
 indicator: 15.9.1
-indicator_name: global_indicators.15-9-1.title
+indicator_name: global_indicators.15-9-1-title
 indicator_sort_order: 15-09-01
 layout: indicator
 permalink: /15-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-9.title
+target: global_targets.15-9-title
 target_id: '15.9'
 un_custodian_agency: CBD-Secretariat,UNEP
 un_designated_tier: '3'

--- a/meta/15-a-1.md
+++ b/meta/15-a-1.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.15-a-1.title
+graph_title: global_indicators.15-a-1-title
 graph_type: line
 indicator: 15.a.1
 indicator_definition: Total ODA flows to developing countries quantify the public
   effort that donors provide to developing countries for biodiversity.
-indicator_name: global_indicators.15-a-1.title
+indicator_name: global_indicators.15-a-1-title
 indicator_sort_order: 15-aa-01
 layout: indicator
 permalink: /15-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-a.title
+target: global_targets.15-a-title
 target_id: 15.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1/3

--- a/meta/15-b-1.md
+++ b/meta/15-b-1.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.15-b-1.title
+graph_title: global_indicators.15-b-1-title
 graph_type: line
 indicator: 15.b.1
 indicator_definition: Total ODA flows to developing countries quantify the public
   effort that donors provide to developing countries for biodiversity.
-indicator_name: global_indicators.15-b-1.title
+indicator_name: global_indicators.15-b-1-title
 indicator_sort_order: 15-bb-01
 layout: indicator
 permalink: /15-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-b.title
+target: global_targets.15-b-title
 target_id: 15.b
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: 1/3

--- a/meta/15-c-1.md
+++ b/meta/15-c-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
-graph_title: global_indicators.15-c-1.title
+graph_title: global_indicators.15-c-1-title
 graph_type: line
 indicator: 15.c.1
-indicator_name: global_indicators.15-c-1.title
+indicator_name: global_indicators.15-c-1-title
 indicator_sort_order: 15-cc-01
 layout: indicator
 permalink: /15-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '15'
-target: global_targets.15-c.title
+target: global_targets.15-c-title
 target_id: 15.c
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '2'

--- a/meta/16-1-1.md
+++ b/meta/16-1-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 222
   KB)
-graph_title: global_indicators.16-1-1.title
+graph_title: global_indicators.16-1-1-title
 graph_type: line
 indicator: 16.1.1
-indicator_name: global_indicators.16-1-1.title
+indicator_name: global_indicators.16-1-1-title
 indicator_sort_order: 16-01-01
 layout: indicator
 permalink: /16-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-1.title
+target: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC) World Health
   Organization (WHO)

--- a/meta/16-1-2.md
+++ b/meta/16-1-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 1.3
   MB)
-graph_title: global_indicators.16-1-2.title
+graph_title: global_indicators.16-1-2-title
 graph_type: line
 indicator: 16.1.2
-indicator_name: global_indicators.16-1-2.title
+indicator_name: global_indicators.16-1-2-title
 indicator_sort_order: 16-01-02
 layout: indicator
 permalink: /16-1-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-1.title
+target: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/16-1-3.md
+++ b/meta/16-1-3.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-03.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 217
   KB)
-graph_title: global_indicators.16-1-3.title
+graph_title: global_indicators.16-1-3-title
 graph_type: line
 indicator: 16.1.3
-indicator_name: global_indicators.16-1-3.title
+indicator_name: global_indicators.16-1-3-title
 indicator_sort_order: 16-01-03
 layout: indicator
 permalink: /16-1-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-1.title
+target: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-1-4.md
+++ b/meta/16-1-4.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213
   KB)
-graph_title: global_indicators.16-1-4.title
+graph_title: global_indicators.16-1-4-title
 graph_type: line
 indicator: 16.1.4
-indicator_name: global_indicators.16-1-4.title
+indicator_name: global_indicators.16-1-4-title
 indicator_sort_order: 16-01-04
 layout: indicator
 permalink: /16-1-4/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-1.title
+target: global_targets.16-1-title
 target_id: '16.1'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: 2

--- a/meta/16-10-1.md
+++ b/meta/16-10-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-10-1.title
+graph_title: global_indicators.16-10-1-title
 graph_type: line
 indicator: 16.10.1
-indicator_name: global_indicators.16-10-1.title
+indicator_name: global_indicators.16-10-1-title
 indicator_sort_order: 16-10-01
 layout: indicator
 permalink: /16-10-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-10.title
+target: global_targets.16-10-title
 target_id: '16.10'
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/16-10-2.md
+++ b/meta/16-10-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-10-2.title
+graph_title: global_indicators.16-10-2-title
 graph_type: line
 indicator: 16.10.2
-indicator_name: global_indicators.16-10-2.title
+indicator_name: global_indicators.16-10-2-title
 indicator_sort_order: 16-10-02
 layout: indicator
 permalink: /16-10-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-10.title
+target: global_targets.16-10-title
 target_id: '16.10'
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '2'

--- a/meta/16-2-1.md
+++ b/meta/16-2-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-2-1.title
+graph_title: global_indicators.16-2-1-title
 graph_type: line
 indicator: 16.2.1
-indicator_name: global_indicators.16-2-1.title
+indicator_name: global_indicators.16-2-1-title
 indicator_sort_order: 16-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.16-2.title
+target: global_targets.16-2-title
 target_id: '16.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '2'

--- a/meta/16-2-2.md
+++ b/meta/16-2-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-2-2.title
+graph_title: global_indicators.16-2-2-title
 graph_type: line
 indicator: 16.2.2
-indicator_name: global_indicators.16-2-2.title
+indicator_name: global_indicators.16-2-2-title
 indicator_sort_order: 16-02-02
 layout: indicator
 permalink: /16-2-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-2.title
+target: global_targets.16-2-title
 target_id: '16.2'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-2-3.md
+++ b/meta/16-2-3.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208
   KB)
-graph_title: global_indicators.16-2-3.title
+graph_title: global_indicators.16-2-3-title
 graph_type: line
 indicator: 16.2.3
 indicator_definition: This indicator provides the proportion of young women and men
@@ -11,14 +11,14 @@ indicator_definition: This indicator provides the proportion of young women and 
   is calculated by dividing the number of young women and men aged 18-24 years who
   report having experienced any sexual violence by age 18 by the total number of young
   women and men aged 18-24 years, respectively, in the population
-indicator_name: global_indicators.16-2-3.title
+indicator_name: global_indicators.16-2-3-title
 indicator_sort_order: 16-02-03
 layout: indicator
 permalink: /16-2-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-2.title
+target: global_targets.16-2-title
 target_id: '16.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '2'

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-3-1.title
+graph_title: global_indicators.16-3-1-title
 graph_type: line
 indicator: 16.3.1
-indicator_name: global_indicators.16-3-1.title
+indicator_name: global_indicators.16-3-1-title
 indicator_sort_order: 16-03-01
 layout: indicator
 permalink: /16-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-3.title
+target: global_targets.16-3-title
 target_id: '16.3'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-3-2.md
+++ b/meta/16-3-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 209
   KB)
-graph_title: global_indicators.16-3-2.title
+graph_title: global_indicators.16-3-2-title
 graph_type: line
 indicator: 16.3.2
-indicator_name: global_indicators.16-3-2.title
+indicator_name: global_indicators.16-3-2-title
 indicator_sort_order: 16-03-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Justice of RA
-target: global_targets.16-3.title
+target: global_targets.16-3-title
 target_id: '16.3'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)
 un_designated_tier: '1'

--- a/meta/16-4-1.md
+++ b/meta/16-4-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-4-1.title
+graph_title: global_indicators.16-4-1-title
 graph_type: line
 indicator: 16.4.1
-indicator_name: global_indicators.16-4-1.title
+indicator_name: global_indicators.16-4-1-title
 indicator_sort_order: 16-04-01
 layout: indicator
 permalink: /16-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-4.title
+target: global_targets.16-4-title
 target_id: '16.4'
 un_custodian_agency: UNODC,UNCTAD
 un_designated_tier: '3'

--- a/meta/16-4-2.md
+++ b/meta/16-4-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-4-2.title
+graph_title: global_indicators.16-4-2-title
 graph_type: line
 indicator: 16.4.2
-indicator_name: global_indicators.16-4-2.title
+indicator_name: global_indicators.16-4-2-title
 indicator_sort_order: 16-04-02
 layout: indicator
 permalink: /16-4-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-4.title
+target: global_targets.16-4-title
 target_id: '16.4'
 un_custodian_agency: UNODC,UNODA
 un_designated_tier: '3'

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-5-1.title
+graph_title: global_indicators.16-5-1-title
 graph_type: line
 indicator: 16.5.1
-indicator_name: global_indicators.16-5-1.title
+indicator_name: global_indicators.16-5-1-title
 indicator_sort_order: 16-05-01
 layout: indicator
 permalink: /16-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-5.title
+target: global_targets.16-5-title
 target_id: '16.5'
 un_custodian_agency: UNODC
 un_designated_tier: '2'

--- a/meta/16-5-2.md
+++ b/meta/16-5-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-5-2.title
+graph_title: global_indicators.16-5-2-title
 graph_type: line
 indicator: 16.5.2
-indicator_name: global_indicators.16-5-2.title
+indicator_name: global_indicators.16-5-2-title
 indicator_sort_order: 16-05-02
 layout: indicator
 permalink: /16-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-5.title
+target: global_targets.16-5-title
 target_id: '16.5'
 un_custodian_agency: World Bank,UNODC
 un_designated_tier: '2'

--- a/meta/16-6-1.md
+++ b/meta/16-6-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-6-1.title
+graph_title: global_indicators.16-6-1-title
 graph_type: line
 indicator: 16.6.1
-indicator_name: global_indicators.16-6-1.title
+indicator_name: global_indicators.16-6-1-title
 indicator_sort_order: 16-06-01
 layout: indicator
 permalink: /16-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-6.title
+target: global_targets.16-6-title
 target_id: '16.6'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/16-6-2.md
+++ b/meta/16-6-2.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-6-2.title
+graph_title: global_indicators.16-6-2-title
 graph_type: line
 indicator: 16.6.2
-indicator_name: global_indicators.16-6-2.title
+indicator_name: global_indicators.16-6-2-title
 indicator_sort_order: 16-06-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
-target: global_targets.16-6.title
+target: global_targets.16-6-title
 target_id: '16.6'
 un_custodian_agency: UNDP
 un_designated_tier: '3'

--- a/meta/16-7-1.md
+++ b/meta/16-7-1.md
@@ -3,20 +3,20 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.16-7-1.title
+graph_title: global_indicators.16-7-1-title
 graph_type: line
 indicator: 16.7.1
 indicator_definition: In order that decision-making be responsive, inclusive, participatory
   and representative, it is important to ensure diversity in representation at all
   levels of State institutions (central, regional and local).
-indicator_name: global_indicators.16-7-1.title
+indicator_name: global_indicators.16-7-1-title
 indicator_sort_order: 16-07-01
 layout: indicator
 permalink: /16-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-7.title
+target: global_targets.16-7-title
 target_id: '16.7'
 un_custodian_agency: United Nations Development Programme (UNDP)
 un_designated_tier: '3'

--- a/meta/16-7-2.md
+++ b/meta/16-7-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/tierIII-indicators/files/Tier3-16-07-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Tier 3 Work Plan
   (PDF 77.8 KB)
-graph_title: global_indicators.16-7-2.title
+graph_title: global_indicators.16-7-2-title
 graph_type: line
 indicator: 16.7.2
-indicator_name: global_indicators.16-7-2.title
+indicator_name: global_indicators.16-7-2-title
 indicator_sort_order: 16-07-02
 layout: indicator
 permalink: /16-7-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-7.title
+target: global_targets.16-7-title
 target_id: '16.7'
 un_custodian_agency: United Nations Development Programme (UNDP)
 un_designated_tier: '3'

--- a/meta/16-8-1.md
+++ b/meta/16-8-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-8-1.title
+graph_title: global_indicators.16-8-1-title
 graph_type: line
 indicator: 16.8.1
-indicator_name: global_indicators.16-8-1.title
+indicator_name: global_indicators.16-8-1-title
 indicator_sort_order: 16-08-01
 layout: indicator
 permalink: /16-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-8.title
+target: global_targets.16-8-title
 target_id: '16.8'
 un_custodian_agency: DESA/FFDO
 un_designated_tier: '1'

--- a/meta/16-9-1.md
+++ b/meta/16-9-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-09-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-9-1.title
+graph_title: global_indicators.16-9-1-title
 graph_type: line
 indicator: 16.9.1
-indicator_name: global_indicators.16-9-1.title
+indicator_name: global_indicators.16-9-1-title
 indicator_sort_order: 16-09-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.16-9.title
+target: global_targets.16-9-title
 target_id: '16.9'
 un_custodian_agency: United Nations Statistics Division (UNSD), United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/16-a-1.md
+++ b/meta/16-a-1.md
@@ -3,10 +3,10 @@ computation_units: data.yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
-graph_title: global_indicators.16-a-1.title
+graph_title: global_indicators.16-a-1-title
 graph_type: line
 indicator: 16.a.1
-indicator_name: global_indicators.16-a-1.title
+indicator_name: global_indicators.16-a-1-title
 indicator_sort_order: 16-aa-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '16'
 source_active_1: true
 source_organisation_1: sources.Human Rights Defender of RA (OMBUDSMAN)
-target: global_targets.16-a.title
+target: global_targets.16-a-title
 target_id: 16.a
 un_custodian_agency: OHCHR
 un_designated_tier: '1'

--- a/meta/16-b-1.md
+++ b/meta/16-b-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.16-b-1.title
+graph_title: global_indicators.16-b-1-title
 graph_type: line
 indicator: 16.b.1
-indicator_name: global_indicators.16-b-1.title
+indicator_name: global_indicators.16-b-1-title
 indicator_sort_order: 16-bb-01
 layout: indicator
 permalink: /16-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '16'
-target: global_targets.16-b.title
+target: global_targets.16-b-title
 target_id: 16.b
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights
   (OHCHR)

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469
   KB)
-graph_title: global_indicators.17-1-1.title
+graph_title: global_indicators.17-1-1-title
 graph_type: line
 indicator: 17.1.1
-indicator_name: global_indicators.17-1-1.title
+indicator_name: global_indicators.17-1-1-title
 indicator_sort_order: 17-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Finance of RA
-target: global_targets.17-1.title
+target: global_targets.17-1-title
 target_id: '17.1'
 un_custodian_agency: International Monetary Fund (IMF)
 un_designated_tier: '1'

--- a/meta/17-1-2.md
+++ b/meta/17-1-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469
   KB)
-graph_title: global_indicators.17-1-2.title
+graph_title: global_indicators.17-1-2-title
 graph_type: line
 indicator: 17.1.2
-indicator_name: global_indicators.17-1-2.title
+indicator_name: global_indicators.17-1-2-title
 indicator_sort_order: 17-01-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Finance of RA
-target: global_targets.17-1.title
+target: global_targets.17-1-title
 target_id: '17.1'
 un_custodian_agency: International Monetary Fund (IMF)
 un_designated_tier: '1'

--- a/meta/17-10-1.md
+++ b/meta/17-10-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-10-1.title
+graph_title: global_indicators.17-10-1-title
 graph_type: line
 indicator: 17.10.1
-indicator_name: global_indicators.17-10-1.title
+indicator_name: global_indicators.17-10-1-title
 indicator_sort_order: 17-10-01
 layout: indicator
 permalink: /17-10-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-10.title
+target: global_targets.17-10-title
 target_id: '17.10'
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'

--- a/meta/17-11-1.md
+++ b/meta/17-11-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-11-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-11-1.title
+graph_title: global_indicators.17-11-1-title
 graph_type: line
 indicator: 17.11.1
-indicator_name: global_indicators.17-11-1.title
+indicator_name: global_indicators.17-11-1-title
 indicator_sort_order: 17-11-01
 layout: indicator
 permalink: /17-11-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-11.title
+target: global_targets.17-11-title
 target_id: '17.11'
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'

--- a/meta/17-12-1.md
+++ b/meta/17-12-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-12-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-12-1.title
+graph_title: global_indicators.17-12-1-title
 graph_type: line
 indicator: 17.12.1
-indicator_name: global_indicators.17-12-1.title
+indicator_name: global_indicators.17-12-1-title
 indicator_sort_order: 17-12-01
 layout: indicator
 permalink: /17-12-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-12.title
+target: global_targets.17-12-title
 target_id: '17.12'
 un_custodian_agency: WTO,ITC,UNCTAD
 un_designated_tier: '1'

--- a/meta/17-13-1.md
+++ b/meta/17-13-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-13-1.title
+graph_title: global_indicators.17-13-1-title
 graph_type: line
 indicator: 17.13.1
-indicator_name: global_indicators.17-13-1.title
+indicator_name: global_indicators.17-13-1-title
 indicator_sort_order: 17-13-01
 layout: indicator
 permalink: /17-13-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-13.title
+target: global_targets.17-13-title
 target_id: '17.13'
 un_custodian_agency: World Bank
 un_designated_tier: '3'

--- a/meta/17-14-1.md
+++ b/meta/17-14-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-14-1.title
+graph_title: global_indicators.17-14-1-title
 graph_type: line
 indicator: 17.14.1
-indicator_name: global_indicators.17-14-1.title
+indicator_name: global_indicators.17-14-1-title
 indicator_sort_order: 17-14-01
 layout: indicator
 permalink: /17-14-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-14.title
+target: global_targets.17-14-title
 target_id: '17.14'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/17-15-1.md
+++ b/meta/17-15-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-15-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-15-1.title
+graph_title: global_indicators.17-15-1-title
 graph_type: line
 indicator: 17.15.1
-indicator_name: global_indicators.17-15-1.title
+indicator_name: global_indicators.17-15-1-title
 indicator_sort_order: 17-15-01
 layout: indicator
 permalink: /17-15-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-15.title
+target: global_targets.17-15-title
 target_id: '17.15'
 un_custodian_agency: OECD, UNDP
 un_designated_tier: '2'

--- a/meta/17-16-1.md
+++ b/meta/17-16-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-16-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-16-1.title
+graph_title: global_indicators.17-16-1-title
 graph_type: line
 indicator: 17.16.1
-indicator_name: global_indicators.17-16-1.title
+indicator_name: global_indicators.17-16-1-title
 indicator_sort_order: 17-16-01
 layout: indicator
 permalink: /17-16-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-16.title
+target: global_targets.17-16-title
 target_id: '17.16'
 un_custodian_agency: OECD, UNDP
 un_designated_tier: '2'

--- a/meta/17-17-1.md
+++ b/meta/17-17-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-17-1.title
+graph_title: global_indicators.17-17-1-title
 graph_type: line
 indicator: 17.17.1
-indicator_name: global_indicators.17-17-1.title
+indicator_name: global_indicators.17-17-1-title
 indicator_sort_order: 17-17-01
 layout: indicator
 permalink: /17-17-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-17.title
+target: global_targets.17-17-title
 target_id: '17.17'
 un_custodian_agency: World Bank
 un_designated_tier: '3'

--- a/meta/17-18-1.md
+++ b/meta/17-18-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-18-1.title
+graph_title: global_indicators.17-18-1-title
 graph_type: line
 indicator: 17.18.1
-indicator_name: global_indicators.17-18-1.title
+indicator_name: global_indicators.17-18-1-title
 indicator_sort_order: 17-18-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.17-18.title
+target: global_targets.17-18-title
 target_id: '17.18'
 un_custodian_agency: UNSD
 un_designated_tier: '3'

--- a/meta/17-18-2.md
+++ b/meta/17-18-2.md
@@ -3,10 +3,10 @@ computation_units: data.yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-18-2.title
+graph_title: global_indicators.17-18-2-title
 graph_type: line
 indicator: 17.18.2
-indicator_name: global_indicators.17-18-2.title
+indicator_name: global_indicators.17-18-2-title
 indicator_sort_order: 17-18-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.17-18.title
+target: global_targets.17-18-title
 target_id: '17.18'
 un_custodian_agency: UNSD,PARIS21, Regional Commissions,World Bank
 un_designated_tier: '2'

--- a/meta/17-18-3.md
+++ b/meta/17-18-3.md
@@ -3,10 +3,10 @@ computation_units: data.yes=1, no=0
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-18-3.title
+graph_title: global_indicators.17-18-3-title
 graph_type: line
 indicator: 17.18.3
-indicator_name: global_indicators.17-18-3.title
+indicator_name: global_indicators.17-18-3-title
 indicator_sort_order: 17-18-03
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.17-18.title
+target: global_targets.17-18-title
 target_id: '17.18'
 un_custodian_agency: PARIS21
 un_designated_tier: '1'

--- a/meta/17-19-1.md
+++ b/meta/17-19-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-19-1.title
+graph_title: global_indicators.17-19-1-title
 graph_type: line
 indicator: 17.19.1
-indicator_name: global_indicators.17-19-1.title
+indicator_name: global_indicators.17-19-1-title
 indicator_sort_order: 17-19-01
 layout: indicator
 permalink: /17-19-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-19.title
+target: global_targets.17-19-title
 target_id: '17.19'
 un_custodian_agency: PARIS21
 un_designated_tier: '1'

--- a/meta/17-19-2.md
+++ b/meta/17-19-2.md
@@ -2,10 +2,10 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-02a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-19-2.title
+graph_title: global_indicators.17-19-2-title
 graph_type: line
 indicator: 17.19.2
-indicator_name: global_indicators.17-19-2.title
+indicator_name: global_indicators.17-19-2-title
 indicator_sort_order: 17-19-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -15,7 +15,7 @@ reporting_status: complete
 sdg_goal: '17'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.17-19.title
+target: global_targets.17-19-title
 target_id: '17.19'
 un_custodian_agency: UNSD
 un_designated_tier: '1'

--- a/meta/17-2-1.md
+++ b/meta/17-2-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-2-1.title
+graph_title: global_indicators.17-2-1-title
 graph_type: line
 indicator: 17.2.1
-indicator_name: global_indicators.17-2-1.title
+indicator_name: global_indicators.17-2-1-title
 indicator_sort_order: 17-02-01
 layout: indicator
 permalink: /17-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-2.title
+target: global_targets.17-2-title
 target_id: '17.2'
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/17-3-1.md
+++ b/meta/17-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-3-1.title
+graph_title: global_indicators.17-3-1-title
 graph_type: line
 indicator: 17.3.1
-indicator_name: global_indicators.17-3-1.title
+indicator_name: global_indicators.17-3-1-title
 indicator_sort_order: 17-03-01
 layout: indicator
 permalink: /17-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-3.title
+target: global_targets.17-3-title
 target_id: '17.3'
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD),
   United Nations Conference on Trade and Development (UNCTAD)

--- a/meta/17-3-2.md
+++ b/meta/17-3-2.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-3-2.title
+graph_title: global_indicators.17-3-2-title
 graph_type: line
 indicator: 17.3.2
-indicator_name: global_indicators.17-3-2.title
+indicator_name: global_indicators.17-3-2-title
 indicator_sort_order: 17-03-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.The Central Bank of RA
-target: global_targets.17-3.title
+target: global_targets.17-3-title
 target_id: '17.3'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/17-4-1.md
+++ b/meta/17-4-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-4-1.title
+graph_title: global_indicators.17-4-1-title
 graph_type: line
 indicator: 17.4.1
-indicator_name: global_indicators.17-4-1.title
+indicator_name: global_indicators.17-4-1-title
 indicator_sort_order: 17-04-01
 layout: indicator
 permalink: /17-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-4.title
+target: global_targets.17-4-title
 target_id: '17.4'
 un_custodian_agency: World Bank
 un_designated_tier: '1'

--- a/meta/17-5-1.md
+++ b/meta/17-5-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-5-1.title
+graph_title: global_indicators.17-5-1-title
 graph_type: line
 indicator: 17.5.1
-indicator_name: global_indicators.17-5-1.title
+indicator_name: global_indicators.17-5-1-title
 indicator_sort_order: 17-05-01
 layout: indicator
 permalink: /17-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-5.title
+target: global_targets.17-5-title
 target_id: '17.5'
 un_custodian_agency: UNCTAD
 un_designated_tier: '3'

--- a/meta/17-6-1.md
+++ b/meta/17-6-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-6-1.title
+graph_title: global_indicators.17-6-1-title
 graph_type: line
 indicator: 17.6.1
-indicator_name: global_indicators.17-6-1.title
+indicator_name: global_indicators.17-6-1-title
 indicator_sort_order: 17-06-01
 layout: indicator
 permalink: /17-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-6.title
+target: global_targets.17-6-title
 target_id: '17.6'
 un_custodian_agency: United Nations Education,Scientific and Cultural Organisation
   (UNESCO) - Institute for Statistics (UIS)

--- a/meta/17-6-2.md
+++ b/meta/17-6-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-06-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
-graph_title: global_indicators.17-6-2.title
+graph_title: global_indicators.17-6-2-title
 graph_type: line
 indicator: 17.6.2
-indicator_name: global_indicators.17-6-2.title
+indicator_name: global_indicators.17-6-2-title
 indicator_sort_order: 17-06-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Commision regulating Public Services of RA
-target: global_targets.17-6.title
+target: global_targets.17-6-title
 target_id: '17.6'
 un_custodian_agency: International Telecommunication Union (ITU)
 un_designated_tier: '1'

--- a/meta/17-7-1.md
+++ b/meta/17-7-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
-graph_title: global_indicators.17-7-1.title
+graph_title: global_indicators.17-7-1-title
 graph_type: line
 indicator: 17.7.1
-indicator_name: global_indicators.17-7-1.title
+indicator_name: global_indicators.17-7-1-title
 indicator_sort_order: 17-07-01
 layout: indicator
 permalink: /17-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-7.title
+target: global_targets.17-7-title
 target_id: '17.7'
 un_custodian_agency: UNEP-CTCN
 un_designated_tier: '3'

--- a/meta/17-8-1.md
+++ b/meta/17-8-1.md
@@ -4,13 +4,13 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-08-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469
   KB)
-graph_title: global_indicators.17-8-1.title
+graph_title: global_indicators.17-8-1-title
 graph_type: line
 indicator: 17.8.1
 indicator_definition: The indicator proportion of individuals using the Internet is
   defined as the proportion of individuals who used the Internet from any location
   in the last three months.
-indicator_name: global_indicators.17-8-1.title
+indicator_name: global_indicators.17-8-1-title
 indicator_sort_order: 17-08-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -22,7 +22,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.17-8.title
+target: global_targets.17-8-title
 target_id: '17.8'
 un_custodian_agency: International Telecommunications Union (ITU)
 un_designated_tier: '1'

--- a/meta/17-9-1.md
+++ b/meta/17-9-1.md
@@ -3,20 +3,20 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-09-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 209
   KB)
-graph_title: global_indicators.17-9-1.title
+graph_title: global_indicators.17-9-1-title
 graph_type: line
 indicator: 17.9.1
 indicator_definition: Total Overseas Development Aid (ODA) and Other Official Flows
   (OOF) to developing countries quantify the public effort (excluding export credits)
   that donors provide to developing countries.
-indicator_name: global_indicators.17-9-1.title
+indicator_name: global_indicators.17-9-1-title
 indicator_sort_order: 17-09-01
 layout: indicator
 permalink: /17-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '17'
-target: global_targets.17-9.title
+target: global_targets.17-9-title
 target_id: '17.9'
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
   United Nations Environment (UNEP) World Bank (WB)

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: global_indicators.2-1-1.title
+graph_title: global_indicators.2-1-1-title
 graph_type: line
 indicator: 2.1.1
-indicator_name: global_indicators.2-1-1.title
+indicator_name: global_indicators.2-1-1-title
 indicator_sort_order: 02-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
-target: global_targets.2-1.title
+target: global_targets.2-1-title
 target_id: '2.1'
 un_custodian_agency: FAO
 un_designated_tier: '1'

--- a/meta/2-1-2.md
+++ b/meta/2-1-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 426
   KB)
-graph_title: global_indicators.2-1-2.title
+graph_title: global_indicators.2-1-2-title
 graph_type: line
 indicator: 2.1.2
-indicator_name: global_indicators.2-1-2.title
+indicator_name: global_indicators.2-1-2-title
 indicator_sort_order: 02-01-02
 layout: indicator
 permalink: /2-1-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-1.title
+target: global_targets.2-1-title
 target_id: '2.1'
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '1'

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: global_indicators.2-2-1.title
+graph_title: global_indicators.2-2-1-title
 graph_type: line
 indicator: 2.2.1
-indicator_name: global_indicators.2-2-1.title
+indicator_name: global_indicators.2-2-1-title
 indicator_sort_order: 02-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.2-2.title
+target: global_targets.2-2-title
 target_id: '2.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '1'

--- a/meta/2-2-2.md
+++ b/meta/2-2-2.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-02a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: global_indicators.2-2-2.title
+graph_title: global_indicators.2-2-2-title
 graph_type: line
 indicator: 2.2.2
-indicator_name: global_indicators.2-2-2.title
+indicator_name: global_indicators.2-2-2-title
 indicator_sort_order: 02-02-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.2-2.title
+target: global_targets.2-2-title
 target_id: '2.2'
 un_custodian_agency: UNICEF
 un_designated_tier: '1'

--- a/meta/2-3-1.md
+++ b/meta/2-3-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-2.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.2-3-1.title
+graph_title: global_indicators.2-3-1-title
 graph_type: line
 indicator: 2.3.1
-indicator_name: global_indicators.2-3-1.title
+indicator_name: global_indicators.2-3-1-title
 indicator_sort_order: 02-03-01
 layout: indicator
 permalink: /2-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-3.title
+target: global_targets.2-3-title
 target_id: '2.3'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '3'

--- a/meta/2-3-2.md
+++ b/meta/2-3-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-2.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.2-3-2.title
+graph_title: global_indicators.2-3-2-title
 graph_type: line
 indicator: 2.3.2
-indicator_name: global_indicators.2-3-2.title
+indicator_name: global_indicators.2-3-2-title
 indicator_sort_order: 02-03-02
 layout: indicator
 permalink: /2-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-3.title
+target: global_targets.2-3-title
 target_id: '2.3'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '3'

--- a/meta/2-4-1.md
+++ b/meta/2-4-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.2-4-1.title
+graph_title: global_indicators.2-4-1-title
 graph_type: line
 indicator: 2.4.1
-indicator_name: global_indicators.2-4-1.title
+indicator_name: global_indicators.2-4-1-title
 indicator_sort_order: 02-04-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '2'
 source_active_1: true
 source_organisation_1: sources.Ministry of Agriculture of RA
-target: global_targets.2-4.title
+target: global_targets.2-4-title
 target_id: '2.4'
 un_custodian_agency: Food and Agriculture Organization (FAO)
 un_designated_tier: '3'

--- a/meta/2-5-1.md
+++ b/meta/2-5-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 334
   KB)
-graph_title: global_indicators.2-5-1.title
+graph_title: global_indicators.2-5-1-title
 graph_type: line
 indicator: 2.5.1
-indicator_name: global_indicators.2-5-1.title
+indicator_name: global_indicators.2-5-1-title
 indicator_sort_order: 02-05-01
 layout: indicator
 permalink: /2-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-5.title
+target: global_targets.2-5-title
 target_id: '2.5'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '1'

--- a/meta/2-5-2.md
+++ b/meta/2-5-2.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 220
   KB)
-graph_title: global_indicators.2-5-2.title
+graph_title: global_indicators.2-5-2-title
 graph_type: line
 indicator: 2.5.2
 indicator_definition: Proportion of local breeds classified as being at risk, not-at-risk
   or at unknown level of risk extinction
-indicator_name: global_indicators.2-5-2.title
+indicator_name: global_indicators.2-5-2-title
 indicator_sort_order: 02-05-02
 layout: indicator
 permalink: /2-5-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-5.title
+target: global_targets.2-5-title
 target_id: '2.5'
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '1'

--- a/meta/2-a-1.md
+++ b/meta/2-a-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 223
   KB)
-graph_title: global_indicators.2-a-1.title
+graph_title: global_indicators.2-a-1-title
 graph_type: line
 indicator: 2.a.1
 indicator_definition: An Agriculture Orientation Index (AOI) greater than 1 reflects
@@ -11,14 +11,14 @@ indicator_definition: An Agriculture Orientation Index (AOI) greater than 1 refl
   of government spending relative to its contribution to economic value-added. An
   AOI less than 1 reflects a lower orientation to agriculture, while an AOI equal
   to 1 reflects neutrality in a government’s orientation to the agriculture sector.
-indicator_name: global_indicators.2-a-1.title
+indicator_name: global_indicators.2-a-1-title
 indicator_sort_order: 02-aa-01
 layout: indicator
 permalink: /2-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-a.title
+target: global_targets.2-a-title
 target_id: 2.a
 un_custodian_agency: Food and Agricultural Organization (FAO)
 un_designated_tier: '2'

--- a/meta/2-a-2.md
+++ b/meta/2-a-2.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
-graph_title: global_indicators.2-a-2.title
+graph_title: global_indicators.2-a-2-title
 graph_type: line
 indicator: 2.a.2
 indicator_definition: Gross disbursements of total ODA and other official flows from
   all donors to the agriculture sector.
-indicator_name: global_indicators.2-a-2.title
+indicator_name: global_indicators.2-a-2-title
 indicator_sort_order: 02-aa-02
 layout: indicator
 permalink: /2-a-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-a.title
+target: global_targets.2-a-title
 target_id: 2.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/2-b-1.md
+++ b/meta/2-b-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: global_indicators.2-b-1.title
+graph_title: global_indicators.2-b-1-title
 graph_type: line
 indicator: 2.b.1
-indicator_name: global_indicators.2-b-1.title
+indicator_name: global_indicators.2-b-1-title
 indicator_sort_order: 02-bb-01
 layout: indicator
 permalink: /2-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-b.title
+target: global_targets.2-b-title
 target_id: 2.b
 un_custodian_agency: WTO
 un_designated_tier: '1'

--- a/meta/2-c-1.md
+++ b/meta/2-c-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)
-graph_title: global_indicators.2-c-1.title
+graph_title: global_indicators.2-c-1-title
 graph_type: line
 indicator: 2.c.1
-indicator_name: global_indicators.2-c-1.title
+indicator_name: global_indicators.2-c-1-title
 indicator_sort_order: 02-cc-01
 layout: indicator
 permalink: /2-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '2'
-target: global_targets.2-c.title
+target: global_targets.2-c-title
 target_id: 2.c
 un_custodian_agency: FAO
 un_designated_tier: '2'

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -3,10 +3,10 @@ computation_units: data.per 100,000 live births
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: global_indicators.3-1-1.title
+graph_title: global_indicators.3-1-1-title
 graph_type: line
 indicator: 3.1.1
-indicator_name: global_indicators.3-1-1.title
+indicator_name: global_indicators.3-1-1-title
 indicator_sort_order: 03-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.3-1.title
+target: global_targets.3-1-title
 target_id: '3.1'
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/3-1-2.md
+++ b/meta/3-1-2.md
@@ -4,11 +4,11 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 374
   KB)
-graph_title: global_indicators.3-1-2.title
+graph_title: global_indicators.3-1-2-title
 graph_type: line
 indicator: 3.1.2
 indicator_definition: Percentage of births attended by skilled health personnel
-indicator_name: global_indicators.3-1-2.title
+indicator_name: global_indicators.3-1-2-title
 indicator_sort_order: 03-01-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -20,7 +20,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.3-1.title
+target: global_targets.3-1-title
 target_id: '3.1'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '1'

--- a/meta/3-2-1.md
+++ b/meta/3-2-1.md
@@ -4,7 +4,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 225
   KB)
-graph_title: global_indicators.3-2-1.title
+graph_title: global_indicators.3-2-1-title
 graph_type: line
 indicator: 3.2.1
 indicator_definition: The probability of a child born in a specific year or period
@@ -13,7 +13,7 @@ indicator_definition: The probability of a child born in a specific year or peri
   defined here is, strictly speaking, not a rate (i.e. the number of deaths divided
   by the number of population at risk during a certain period of time) but a probability
   of death derived from a life table and expressed as a rate per 1000 live births.
-indicator_name: global_indicators.3-2-1.title
+indicator_name: global_indicators.3-2-1-title
 indicator_sort_order: 03-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -23,7 +23,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.3-2.title
+target: global_targets.3-2-title
 target_id: '3.2'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '1'

--- a/meta/3-2-2.md
+++ b/meta/3-2-2.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 225
   KB)
-graph_title: global_indicators.3-2-2.title
+graph_title: global_indicators.3-2-2-title
 graph_type: line
 indicator: 3.2.2
 indicator_definition: Probability that a child born in a specific year or period will
@@ -12,7 +12,7 @@ indicator_definition: Probability that a child born in a specific year or period
   live births during the first 28 completed days of life) may be subdivided into early
   neonatal deaths, occurring during the first 7 days of life, and late neonatal deaths,
   occurring after the 7th day but before the 28th completed day of life.
-indicator_name: global_indicators.3-2-2.title
+indicator_name: global_indicators.3-2-2-title
 indicator_sort_order: 03-02-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -20,7 +20,7 @@ permalink: /3-2-2/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: global_targets.3-2.title
+target: global_targets.3-2-title
 target_id: '3.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '1'

--- a/meta/3-3-1.md
+++ b/meta/3-3-1.md
@@ -4,12 +4,12 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 372
   KB)
-graph_title: global_indicators.3-3-1.title
+graph_title: global_indicators.3-3-1-title
 graph_type: line
 indicator: 3.3.1
 indicator_definition: Number of new HIV infections per 1,000 uninfected population,
   by sex, age and key populations
-indicator_name: global_indicators.3-3-1.title
+indicator_name: global_indicators.3-3-1-title
 indicator_sort_order: 03-03-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Ministry of Health of RA
-target: global_targets.3-3.title
+target: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: The Joint United Nations Programme on HIV/AIDS (UNAIDS)
 un_designated_tier: '2'

--- a/meta/3-3-2.md
+++ b/meta/3-3-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 61
   KB)
-graph_title: global_indicators.3-3-2.title
+graph_title: global_indicators.3-3-2-title
 graph_type: line
 indicator: 3.3.2
-indicator_name: global_indicators.3-3-2.title
+indicator_name: global_indicators.3-3-2-title
 indicator_sort_order: 03-03-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Health of RA
-target: global_targets.3-3.title
+target: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: World Health Organization (WHO)
 un_designated_tier: '1'

--- a/meta/3-3-3.md
+++ b/meta/3-3-3.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 431
   KB)
-graph_title: global_indicators.3-3-3.title
+graph_title: global_indicators.3-3-3-title
 graph_type: line
 indicator: 3.3.3
-indicator_name: global_indicators.3-3-3.title
+indicator_name: global_indicators.3-3-3-title
 indicator_sort_order: 03-03-03
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Health of RA
-target: global_targets.3-3.title
+target: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: 1

--- a/meta/3-3-4.md
+++ b/meta/3-3-4.md
@@ -3,10 +3,10 @@ computation_units: data.per 100,000 population
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: global_indicators.3-3-4.title
+graph_title: global_indicators.3-3-4-title
 graph_type: line
 indicator: 3.3.4
-indicator_name: global_indicators.3-3-4.title
+indicator_name: global_indicators.3-3-4-title
 indicator_sort_order: 03-03-04
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Health of RA
-target: global_targets.3-3.title
+target: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '2'

--- a/meta/3-3-5.md
+++ b/meta/3-3-5.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-05.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: global_indicators.3-3-5.title
+graph_title: global_indicators.3-3-5-title
 graph_type: line
 indicator: 3.3.5
-indicator_name: global_indicators.3-3-5.title
+indicator_name: global_indicators.3-3-5-title
 indicator_sort_order: 03-03-05
 layout: indicator
 permalink: /3-3-5/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: global_targets.3-3.title
+target: global_targets.3-3-title
 target_id: '3.3'
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/3-4-1.md
+++ b/meta/3-4-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 72.6
   KB)
-graph_title: global_indicators.3-4-1.title
+graph_title: global_indicators.3-4-1-title
 graph_type: line
 indicator: 3.4.1
 indicator_definition: Probability of dying between the ages of 30 and 70 years from
@@ -12,7 +12,7 @@ indicator_definition: Probability of dying between the ages of 30 and 70 years f
   cardiovascular disease, cancer, diabetes, or chronic respiratory disease, assuming
   that s/he would experience current mortality rates at every age and s/he would not
   die from any other cause of death.
-indicator_name: global_indicators.3-4-1.title
+indicator_name: global_indicators.3-4-1-title
 indicator_sort_order: 03-04-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -20,7 +20,7 @@ permalink: /3-4-1/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: global_targets.3-4.title
+target: global_targets.3-4-title
 target_id: '3.4'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-4-2.md
+++ b/meta/3-4-2.md
@@ -4,11 +4,11 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 65.1
   KB)
-graph_title: global_indicators.3-4-2.title
+graph_title: global_indicators.3-4-2-title
 graph_type: line
 indicator: 3.4.2
 indicator_definition: Suicide mortality rates
-indicator_name: global_indicators.3-4-2.title
+indicator_name: global_indicators.3-4-2-title
 indicator_sort_order: 03-04-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.3-4.title
+target: global_targets.3-4-title
 target_id: '3.4'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-5-1.md
+++ b/meta/3-5-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: global_indicators.3-5-1.title
+graph_title: global_indicators.3-5-1-title
 graph_type: line
 indicator: 3.5.1
-indicator_name: global_indicators.3-5-1.title
+indicator_name: global_indicators.3-5-1-title
 indicator_sort_order: 03-05-01
 layout: indicator
 permalink: /3-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: global_targets.3-5.title
+target: global_targets.3-5-title
 target_id: '3.5'
 un_custodian_agency: WHO,UNODC
 un_designated_tier: '3'

--- a/meta/3-5-2.md
+++ b/meta/3-5-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214
   KB)
-graph_title: global_indicators.3-5-2.title
+graph_title: global_indicators.3-5-2-title
 graph_type: line
 indicator: 3.5.2
-indicator_name: global_indicators.3-5-2.title
+indicator_name: global_indicators.3-5-2-title
 indicator_sort_order: 03-05-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Health of RA
-target: global_targets.3-5.title
+target: global_targets.3-5-title
 target_id: '3.5'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-6-1.md
+++ b/meta/3-6-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213
   KB)
-graph_title: global_indicators.3-6-1.title
+graph_title: global_indicators.3-6-1-title
 graph_type: line
 indicator: 3.6.1
-indicator_name: global_indicators.3-6-1.title
+indicator_name: global_indicators.3-6-1-title
 indicator_sort_order: 03-06-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.3-6.title
+target: global_targets.3-6-title
 target_id: '3.6'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-07-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: global_indicators.3-7-1.title
+graph_title: global_indicators.3-7-1-title
 graph_type: line
 indicator: 3.7.1
-indicator_name: global_indicators.3-7-1.title
+indicator_name: global_indicators.3-7-1-title
 indicator_sort_order: 03-07-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.3-7.title
+target: global_targets.3-7-title
 target_id: '3.7'
 un_custodian_agency: DESA Population Division
 un_designated_tier: '1'

--- a/meta/3-7-2.md
+++ b/meta/3-7-2.md
@@ -3,12 +3,12 @@ data_non_statistical: false
 goal_meta_link: http://data.un.org/Data.aspx?q=births&d=WDI&f=Indicator_Code%3aSP.ADO.TFRT
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 90.8
   KB)
-graph_title: global_indicators.3-7-2.title
+graph_title: global_indicators.3-7-2-title
 graph_type: line
 indicator: 3.7.2
 indicator_definition: Adolescent birth rate (aged 10-14 years; aged 15-19 years) per
   1,000 women in that age group
-indicator_name: global_indicators.3-7-2.title
+indicator_name: global_indicators.3-7-2-title
 indicator_sort_order: 03-07-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ permalink: /3-7-2/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: global_targets.3-7.title
+target: global_targets.3-7-title
 target_id: '3.7'
 un_custodian_agency: Department of Economic and Social Affairs (DESA) Population Division
   United Nations Population Fund (UNFPA )

--- a/meta/3-8-1.md
+++ b/meta/3-8-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: global_indicators.3-8-1.title
+graph_title: global_indicators.3-8-1-title
 graph_type: line
 indicator: 3.8.1
-indicator_name: global_indicators.3-8-1.title
+indicator_name: global_indicators.3-8-1-title
 indicator_sort_order: 03-08-01
 layout: indicator
 permalink: /3-8-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: global_targets.3-8.title
+target: global_targets.3-8-title
 target_id: '3.8'
 un_custodian_agency: WHO
 un_designated_tier: '3'

--- a/meta/3-8-2.md
+++ b/meta/3-8-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.3-8-2.title
+graph_title: global_indicators.3-8-2-title
 graph_type: line
 indicator: 3.8.2
-indicator_name: global_indicators.3-8-2.title
+indicator_name: global_indicators.3-8-2-title
 indicator_sort_order: 03-08-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
-target: global_targets.3-8.title
+target: global_targets.3-8-title
 target_id: '3.8'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '2'

--- a/meta/3-9-1.md
+++ b/meta/3-9-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 216
   KB)
-graph_title: global_indicators.3-9-1.title
+graph_title: global_indicators.3-9-1-title
 graph_type: line
 indicator: 3.9.1
-indicator_name: global_indicators.3-9-1.title
+indicator_name: global_indicators.3-9-1-title
 indicator_sort_order: 03-09-01
 layout: indicator
 permalink: /3-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: global_targets.3-9.title
+target: global_targets.3-9-title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-9-2.md
+++ b/meta/3-9-2.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214
   KB)
-graph_title: global_indicators.3-9-2.title
+graph_title: global_indicators.3-9-2-title
 graph_type: line
 indicator: 3.9.2
 indicator_definition: The mortality rate attributed to unsafe water, unsafe sanitation
@@ -11,7 +11,7 @@ indicator_definition: The mortality rate attributed to unsafe water, unsafe sani
   services) as defined as the number of deaths from unsafe water, unsafe sanitation
   and lack of hygiene (exposure to unsafe WASH services) in a year, divided by the
   population, and multiplied by 1,000,000.
-indicator_name: global_indicators.3-9-2.title
+indicator_name: global_indicators.3-9-2-title
 indicator_sort_order: 03-09-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ permalink: /3-9-2/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: global_targets.3-9.title
+target: global_targets.3-9-title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-9-3.md
+++ b/meta/3-9-3.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213
   KB)
-graph_title: global_indicators.3-9-3.title
+graph_title: global_indicators.3-9-3-title
 graph_type: line
 indicator: 3.9.3
-indicator_name: global_indicators.3-9-3.title
+indicator_name: global_indicators.3-9-3-title
 indicator_sort_order: 03-09-03
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -15,7 +15,7 @@ permalink: /3-9-3/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: global_targets.3-9.title
+target: global_targets.3-9-title
 target_id: '3.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-a-1.md
+++ b/meta/3-a-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 866
   KB)
-graph_title: global_indicators.3-a-1.title
+graph_title: global_indicators.3-a-1-title
 graph_type: line
 indicator: 3.a.1
-indicator_name: global_indicators.3-a-1.title
+indicator_name: global_indicators.3-a-1-title
 indicator_sort_order: 03-aa-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Ministry of Health of RA
-target: global_targets.3-a.title
+target: global_targets.3-a-title
 target_id: 3.a
 un_custodian_agency: World Health Organization (WHO), Framework Convention on Tobacco
   Control (FCTC)

--- a/meta/3-b-1.md
+++ b/meta/3-b-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.3-b-1.title
+graph_title: global_indicators.3-b-1-title
 graph_type: line
 indicator: 3.b.1
-indicator_name: global_indicators.3-b-1.title
+indicator_name: global_indicators.3-b-1-title
 indicator_sort_order: 03-bb-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.3-b.title
+target: global_targets.3-b-title
 target_id: 3.b
 un_custodian_agency: World Health Organization (WHO)  United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/3-b-2.md
+++ b/meta/3-b-2.md
@@ -3,20 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0B-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
-graph_title: global_indicators.3-b-2.title
+graph_title: global_indicators.3-b-2-title
 graph_type: line
 indicator: 3.b.2
 indicator_definition: Total ODA flows to developing countries quantify the public
   effort that donors provide to developing countries for medical research and basic
   health.
-indicator_name: global_indicators.3-b-2.title
+indicator_name: global_indicators.3-b-2-title
 indicator_sort_order: 03-bb-02
 layout: indicator
 permalink: /3-b-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: global_targets.3-b.title
+target: global_targets.3-b-title
 target_id: 3.b
 un_custodian_agency: Organisation for Economic Co-operation (OECD)
 un_designated_tier: '1'

--- a/meta/3-b-3.md
+++ b/meta/3-b-3.md
@@ -1,17 +1,17 @@
 ---
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
-graph_title: global_indicators.3-b-3.title
+graph_title: global_indicators.3-b-3-title
 graph_type: line
 indicator: 3.b.3
-indicator_name: global_indicators.3-b-3.title
+indicator_name: global_indicators.3-b-3-title
 indicator_sort_order: 03-bb-03
 layout: indicator
 permalink: /3-b-3/
 published: true
 reporting_status: notstarted
 sdg_goal: '3'
-target: global_targets.3-b.title
+target: global_targets.3-b-title
 target_id: 3.b
 un_custodian_agency: WHO
 un_designated_tier: '3'

--- a/meta/3-c-1.md
+++ b/meta/3-c-1.md
@@ -3,12 +3,12 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 207
   KB)
-graph_title: global_indicators.3-c-1.title
+graph_title: global_indicators.3-c-1-title
 graph_type: line
 indicator: 3.c.1
 indicator_definition: Density of physicians, nursing and midwifery personnel, dentistry
   personnel, and pharmaceutical personnel per 1,000 persons
-indicator_name: global_indicators.3-c-1.title
+indicator_name: global_indicators.3-c-1-title
 indicator_sort_order: 03-cc-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ permalink: /3-c-1/
 published: true
 reporting_status: complete
 sdg_goal: '3'
-target: global_targets.3-c.title
+target: global_targets.3-c-title
 target_id: 3.c
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '1'

--- a/meta/3-d-1.md
+++ b/meta/3-d-1.md
@@ -3,10 +3,10 @@ computation_units: data.unit
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0D-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
-graph_title: global_indicators.3-d-1.title
+graph_title: global_indicators.3-d-1-title
 graph_type: line
 indicator: 3.d.1
-indicator_name: global_indicators.3-d-1.title
+indicator_name: global_indicators.3-d-1-title
 indicator_sort_order: 03-dd-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '3'
 source_active_1: true
 source_organisation_1: sources.Ministry of Health of RA
-target: global_targets.3-d.title
+target: global_targets.3-d-title
 target_id: 3.d
 un_custodian_agency: WHO
 un_designated_tier: '1'

--- a/meta/4-1-1.md
+++ b/meta/4-1-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.4-1-1.title
+graph_title: global_indicators.4-1-1-title
 graph_type: line
 indicator: 4.1.1
-indicator_name: global_indicators.4-1-1.title
+indicator_name: global_indicators.4-1-1-title
 indicator_sort_order: 04-01-01
 layout: indicator
 permalink: /4-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-1.title
+target: global_targets.4-1-title
 target_id: '4.1'
 un_custodian_agency: UNESCO Institute for Statistics
 un_designated_tier: 3 (a) /2 (b,c)

--- a/meta/4-2-1.md
+++ b/meta/4-2-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.4-2-1.title
+graph_title: global_indicators.4-2-1-title
 graph_type: line
 indicator: 4.2.1
-indicator_name: global_indicators.4-2-1.title
+indicator_name: global_indicators.4-2-1-title
 indicator_sort_order: 04-02-01
 layout: indicator
 permalink: /4-2-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-2.title
+target: global_targets.4-2-title
 target_id: '4.2'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '3'

--- a/meta/4-2-2.md
+++ b/meta/4-2-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 223
   KB)
-graph_title: global_indicators.4-2-2.title
+graph_title: global_indicators.4-2-2-title
 graph_type: line
 indicator: 4.2.2
-indicator_name: global_indicators.4-2-2.title
+indicator_name: global_indicators.4-2-2-title
 indicator_sort_order: 04-02-02
 layout: indicator
 permalink: /4-2-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-2.title
+target: global_targets.4-2-title
 target_id: '4.2'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-3-1.md
+++ b/meta/4-3-1.md
@@ -3,20 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
-graph_title: global_indicators.4-3-1.title
+graph_title: global_indicators.4-3-1-title
 graph_type: line
 indicator: 4.3.1
 indicator_definition: The percentage of youth and adults in a given age range (e.g.
   15-24 years, 25-64 years, etc.) participating in formal or non-formal education
   or training in a given time period (e.g. last 12 months).
-indicator_name: global_indicators.4-3-1.title
+indicator_name: global_indicators.4-3-1-title
 indicator_sort_order: 04-03-01
 layout: indicator
 permalink: /4-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-3.title
+target: global_targets.4-3-title
 target_id: '4.3'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-4-1.md
+++ b/meta/4-4-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214
   KB)
-graph_title: global_indicators.4-4-1.title
+graph_title: global_indicators.4-4-1-title
 graph_type: line
 indicator: 4.4.1
-indicator_name: global_indicators.4-4-1.title
+indicator_name: global_indicators.4-4-1-title
 indicator_sort_order: 04-04-01
 layout: indicator
 permalink: /4-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-4.title
+target: global_targets.4-4-title
 target_id: '4.4'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-5-1.md
+++ b/meta/4-5-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
-graph_title: global_indicators.4-5-1.title
+graph_title: global_indicators.4-5-1-title
 graph_type: line
 indicator: 4.5.1
-indicator_name: global_indicators.4-5-1.title
+indicator_name: global_indicators.4-5-1-title
 indicator_sort_order: 04-05-01
 layout: indicator
 permalink: /4-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-5.title
+target: global_targets.4-5-title
 target_id: '4.5'
 un_custodian_agency: United Nations Educational, Scientific and Cultural Organization
   (UNESCO)

--- a/meta/4-6-1.md
+++ b/meta/4-6-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 57.8
   KB)
-graph_title: global_indicators.4-6-1.title
+graph_title: global_indicators.4-6-1-title
 graph_type: line
 indicator: 4.6.1
-indicator_name: global_indicators.4-6-1.title
+indicator_name: global_indicators.4-6-1-title
 indicator_sort_order: 04-06-01
 layout: indicator
 permalink: /4-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-6.title
+target: global_targets.4-6-title
 target_id: '4.6'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/4-7-1.md
+++ b/meta/4-7-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-4.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
-graph_title: global_indicators.4-7-1.title
+graph_title: global_indicators.4-7-1-title
 graph_type: line
 indicator: 4.7.1
-indicator_name: global_indicators.4-7-1.title
+indicator_name: global_indicators.4-7-1-title
 indicator_sort_order: 04-07-01
 layout: indicator
 permalink: /4-7-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-7.title
+target: global_targets.4-7-title
 target_id: '4.7'
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '3'

--- a/meta/4-a-1.md
+++ b/meta/4-a-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
-graph_title: global_indicators.4-a-1.title
+graph_title: global_indicators.4-a-1-title
 graph_type: line
 indicator: 4.a.1
-indicator_name: global_indicators.4-a-1.title
+indicator_name: global_indicators.4-a-1-title
 indicator_sort_order: 04-aa-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Science and Education of RA
-target: global_targets.4-a.title
+target: global_targets.4-a-title
 target_id: 4.a
 un_custodian_agency: UNESCO-UIS
 un_designated_tier: '2'

--- a/meta/4-b-1.md
+++ b/meta/4-b-1.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
-graph_title: global_indicators.4-b-1.title
+graph_title: global_indicators.4-b-1-title
 graph_type: line
 indicator: 4.b.1
 indicator_definition: Volume of official development assistance flows for scholarships
   by sector and type of study
-indicator_name: global_indicators.4-b-1.title
+indicator_name: global_indicators.4-b-1-title
 indicator_sort_order: 04-bb-01
 layout: indicator
 permalink: /4-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-b.title
+target: global_targets.4-b-title
 target_id: 4.b
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/4-c-1.md
+++ b/meta/4-c-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-04-0C-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 218
   KB)
-graph_title: global_indicators.4-c-1.title
+graph_title: global_indicators.4-c-1-title
 graph_type: line
 indicator: 4.c.1
-indicator_name: global_indicators.4-c-1.title
+indicator_name: global_indicators.4-c-1-title
 indicator_sort_order: 04-cc-01
 layout: indicator
 permalink: /4-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '4'
-target: global_targets.4-c.title
+target: global_targets.4-c-title
 target_id: 4.c
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute of Statistics (UNESCO-UIS)

--- a/meta/5-1-1.md
+++ b/meta/5-1-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
-graph_title: global_indicators.5-1-1.title
+graph_title: global_indicators.5-1-1-title
 graph_type: line
 indicator: 5.1.1
-indicator_name: global_indicators.5-1-1.title
+indicator_name: global_indicators.5-1-1-title
 indicator_sort_order: 05-01-01
 layout: indicator
 permalink: /5-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-1.title
+target: global_targets.5-1-title
 target_id: '5.1'
 un_custodian_agency: UN Women,World Bank,OECD Development Centre
 un_designated_tier: '3'

--- a/meta/5-2-1.md
+++ b/meta/5-2-1.md
@@ -3,13 +3,13 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 518
   KB)
-graph_title: global_indicators.5-2-1.title
+graph_title: global_indicators.5-2-1-title
 graph_type: line
 indicator: 5.2.1
 indicator_definition: Proportion of ever-partnered women and girls aged 15 years and
   older subjected to physical, sexual or psychological violence by a current or former
   intimate partner in the previous 12 months, by form of violence and by age
-indicator_name: global_indicators.5-2-1.title
+indicator_name: global_indicators.5-2-1-title
 indicator_sort_order: 05-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -21,7 +21,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.5-2.title
+target: global_targets.5-2-title
 target_id: '5.2'
 un_custodian_agency: 'United Nations Children’s Fund (UNICEF) The United Nations Entity
   for Gender Equality and the Empowerment of Women (UN Women) United Nations Population

--- a/meta/5-2-2.md
+++ b/meta/5-2-2.md
@@ -3,20 +3,20 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 294
   KB)
-graph_title: global_indicators.5-2-2.title
+graph_title: global_indicators.5-2-2-title
 graph_type: line
 indicator: 5.2.2
 indicator_definition: Proportion of women and girls aged 15 years and older subjected
   to sexual violence by persons other than an intimate partner in the previous 12
   months, by age and place of occurrence
-indicator_name: global_indicators.5-2-2.title
+indicator_name: global_indicators.5-2-2-title
 indicator_sort_order: 05-02-02
 layout: indicator
 permalink: /5-2-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-2.title
+target: global_targets.5-2-title
 target_id: '5.2'
 un_custodian_agency: 'United Nations Children’s Fund (UNICEF) The United Nations Entity
   for Gender Equality and the Empowerment of Women (UN Women) United Nations Population

--- a/meta/5-3-1.md
+++ b/meta/5-3-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 207
   KB)
-graph_title: global_indicators.5-3-1.title
+graph_title: global_indicators.5-3-1-title
 graph_type: line
 indicator: 5.3.1
-indicator_name: global_indicators.5-3-1.title
+indicator_name: global_indicators.5-3-1-title
 indicator_sort_order: 05-03-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -14,7 +14,7 @@ permalink: /5-3-1/
 published: true
 reporting_status: complete
 sdg_goal: '5'
-target: global_targets.5-3.title
+target: global_targets.5-3-title
 target_id: '5.3'
 un_custodian_agency: United Nations Children's Fund (UNICEFF)
 un_designated_tier: '2'

--- a/meta/5-3-2.md
+++ b/meta/5-3-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 206
   KB)
-graph_title: global_indicators.5-3-2.title
+graph_title: global_indicators.5-3-2-title
 graph_type: line
 indicator: 5.3.2
-indicator_name: global_indicators.5-3-2.title
+indicator_name: global_indicators.5-3-2-title
 indicator_sort_order: 05-03-02
 layout: indicator
 permalink: /5-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-3.title
+target: global_targets.5-3-title
 target_id: '5.3'
 un_custodian_agency: United Nations Children's Fund (UNICEF)
 un_designated_tier: '2'

--- a/meta/5-4-1.md
+++ b/meta/5-4-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 337
   KB)
-graph_title: global_indicators.5-4-1.title
+graph_title: global_indicators.5-4-1-title
 graph_type: line
 indicator: 5.4.1
-indicator_name: global_indicators.5-4-1.title
+indicator_name: global_indicators.5-4-1-title
 indicator_sort_order: 05-04-01
 layout: indicator
 permalink: /5-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-4.title
+target: global_targets.5-4-title
 target_id: '5.4'
 un_custodian_agency: UN Statistics Division (UNSD)
 un_designated_tier: '2'

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -4,12 +4,12 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.5-5-1.title
+graph_title: global_indicators.5-5-1-title
 graph_type: line
 indicator: 5.5.1
 indicator_definition: Proportion of seats held by women in (a) national parliaments
   and (b) local governments
-indicator_name: global_indicators.5-5-1.title
+indicator_name: global_indicators.5-5-1-title
 indicator_sort_order: 05-05-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -24,7 +24,7 @@ source_organisation_1: sources.Armstat
 source_organisation_2: sources.National Assemby of RA
 source_organisation_3: sources.Ministry of Territorial Administration and Development
   of RA
-target: global_targets.5-5.title
+target: global_targets.5-5-title
 target_id: '5.5'
 un_custodian_agency: Inter-Parliamentary Union (IPU)
 un_designated_tier: 1/2

--- a/meta/5-5-2.md
+++ b/meta/5-5-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 372
   KB)
-graph_title: global_indicators.5-5-2.title
+graph_title: global_indicators.5-5-2-title
 graph_type: line
 indicator: 5.5.2
-indicator_name: global_indicators.5-5-2.title
+indicator_name: global_indicators.5-5-2-title
 indicator_sort_order: 05-05-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '5'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.5-5.title
+target: global_targets.5-5-title
 target_id: '5.5'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
-graph_title: global_indicators.5-6-1.title
+graph_title: global_indicators.5-6-1-title
 graph_type: line
 indicator: 5.6.1
-indicator_name: global_indicators.5-6-1.title
+indicator_name: global_indicators.5-6-1-title
 indicator_sort_order: 05-06-01
 layout: indicator
 permalink: /5-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-6.title
+target: global_targets.5-6-title
 target_id: '5.6'
 un_custodian_agency: UNFPA
 un_designated_tier: '2'

--- a/meta/5-6-2.md
+++ b/meta/5-6-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
-graph_title: global_indicators.5-6-2.title
+graph_title: global_indicators.5-6-2-title
 graph_type: line
 indicator: 5.6.2
-indicator_name: global_indicators.5-6-2.title
+indicator_name: global_indicators.5-6-2-title
 indicator_sort_order: 05-06-02
 layout: indicator
 permalink: /5-6-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-6.title
+target: global_targets.5-6-title
 target_id: '5.6'
 un_custodian_agency: UNFPA
 un_designated_tier: '3'

--- a/meta/5-a-1.md
+++ b/meta/5-a-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.5-a-1.title
+graph_title: global_indicators.5-a-1-title
 graph_type: line
 indicator: 5.a.1
-indicator_name: global_indicators.5-a-1.title
+indicator_name: global_indicators.5-a-1-title
 indicator_sort_order: 05-aa-01
 layout: indicator
 permalink: /5-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-a.title
+target: global_targets.5-a-title
 target_id: 5.a
 un_custodian_agency: United Nations Entity for Gender Equality and the Empowerment
   of Women (UN Women) United Nations Statistics Division (UNSD) Food and Agriculture

--- a/meta/5-a-2.md
+++ b/meta/5-a-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
-graph_title: global_indicators.5-a-2.title
+graph_title: global_indicators.5-a-2-title
 graph_type: line
 indicator: 5.a.2
-indicator_name: global_indicators.5-a-2.title
+indicator_name: global_indicators.5-a-2-title
 indicator_sort_order: 05-aa-02
 layout: indicator
 permalink: /5-a-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-a.title
+target: global_targets.5-a-title
 target_id: 5.a
 un_custodian_agency: FAO,World Bank, UN Women
 un_designated_tier: '2'

--- a/meta/5-b-1.md
+++ b/meta/5-b-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
-graph_title: global_indicators.5-b-1.title
+graph_title: global_indicators.5-b-1-title
 graph_type: line
 indicator: 5.b.1
-indicator_name: global_indicators.5-b-1.title
+indicator_name: global_indicators.5-b-1-title
 indicator_sort_order: 05-bb-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.5-b.title
+target: global_targets.5-b-title
 target_id: 5.b
 un_custodian_agency: International Telecommunication Union (ITU)
 un_designated_tier: '1'

--- a/meta/5-c-1.md
+++ b/meta/5-c-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)
-graph_title: global_indicators.5-c-1.title
+graph_title: global_indicators.5-c-1-title
 graph_type: line
 indicator: 5.c.1
-indicator_name: global_indicators.5-c-1.title
+indicator_name: global_indicators.5-c-1-title
 indicator_sort_order: 05-cc-01
 layout: indicator
 permalink: /5-c-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '5'
-target: global_targets.5-c.title
+target: global_targets.5-c-title
 target_id: 5.c
 un_custodian_agency: UN Women,OECD
 un_designated_tier: '2'

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: global_indicators.6-1-1.title
+graph_title: global_indicators.6-1-1-title
 graph_type: line
 indicator: 6.1.1
-indicator_name: global_indicators.6-1-1.title
+indicator_name: global_indicators.6-1-1-title
 indicator_sort_order: 06-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.6-1.title
+target: global_targets.6-1-title
 target_id: '6.1'
 un_custodian_agency: World Health Organisation (WHO), United Nations Children's Emergency
   Fund (UNICEF)

--- a/meta/6-2-1.md
+++ b/meta/6-2-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: global_indicators.6-2-1.title
+graph_title: global_indicators.6-2-1-title
 graph_type: line
 indicator: 6.2.1
-indicator_name: global_indicators.6-2-1.title
+indicator_name: global_indicators.6-2-1-title
 indicator_sort_order: 06-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.ILCS
-target: global_targets.6-2.title
+target: global_targets.6-2-title
 target_id: '6.2'
 un_custodian_agency: World Health Organisation (WHO), United Nations International
   Children's Emergency Fund (UNICEF)

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: global_indicators.6-3-1.title
+graph_title: global_indicators.6-3-1-title
 graph_type: line
 indicator: 6.3.1
-indicator_name: global_indicators.6-3-1.title
+indicator_name: global_indicators.6-3-1-title
 indicator_sort_order: 06-03-01
 layout: indicator
 permalink: /6-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: global_targets.6-3.title
+target: global_targets.6-3-title
 target_id: '6.3'
 un_custodian_agency: WHO, UN-Habitat,UNSD
 un_designated_tier: '2'

--- a/meta/6-3-2.md
+++ b/meta/6-3-2.md
@@ -3,21 +3,21 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.6-3-2.title
+graph_title: global_indicators.6-3-2-title
 graph_type: line
 indicator: 6.3.2
 indicator_definition: Proportion of water bodies (area) in a country with good ambient
   water quality compared to all water bodies in the country. “Good” indicates an ambient
   water quality that does not damage ecosystem function and human health according
   to core ambient water quality indicators.
-indicator_name: global_indicators.6-3-2.title
+indicator_name: global_indicators.6-3-2-title
 indicator_sort_order: 06-03-02
 layout: indicator
 permalink: /6-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: global_targets.6-3.title
+target: global_targets.6-3-title
 target_id: '6.3'
 un_custodian_agency: United Nations Environment Programme (UNEP) (GEMS/Water)
 un_designated_tier: '3'

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: global_indicators.6-4-1.title
+graph_title: global_indicators.6-4-1-title
 graph_type: line
 indicator: 6.4.1
-indicator_name: global_indicators.6-4-1.title
+indicator_name: global_indicators.6-4-1-title
 indicator_sort_order: 06-04-01
 layout: indicator
 permalink: /6-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: global_targets.6-4.title
+target: global_targets.6-4-title
 target_id: '6.4'
 un_custodian_agency: FAO
 un_designated_tier: '2'

--- a/meta/6-4-2.md
+++ b/meta/6-4-2.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: global_indicators.6-4-2.title
+graph_title: global_indicators.6-4-2-title
 graph_type: line
 indicator: 6.4.2
-indicator_name: global_indicators.6-4-2.title
+indicator_name: global_indicators.6-4-2-title
 indicator_sort_order: 06-04-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -22,7 +22,7 @@ source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Nature Protection of RA
 source_organisation_3: sources.Ministry of Emergency situations of RA
 source_organisation_4: sources.Armenian State Hydrometeorological and Monitoring Service
-target: global_targets.6-4.title
+target: global_targets.6-4-title
 target_id: '6.4'
 un_custodian_agency: FAO
 un_designated_tier: '1'

--- a/meta/6-5-1.md
+++ b/meta/6-5-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-06-05-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 410
   KB)
-graph_title: global_indicators.6-5-1.title
+graph_title: global_indicators.6-5-1-title
 graph_type: line
 indicator: 6.5.1
-indicator_name: global_indicators.6-5-1.title
+indicator_name: global_indicators.6-5-1-title
 indicator_sort_order: 06-05-01
 layout: indicator
 permalink: /6-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: global_targets.6-5.title
+target: global_targets.6-5-title
 target_id: '6.5'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '1'

--- a/meta/6-5-2.md
+++ b/meta/6-5-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.6-5-2.title
+graph_title: global_indicators.6-5-2-title
 graph_type: line
 indicator: 6.5.2
-indicator_name: global_indicators.6-5-2.title
+indicator_name: global_indicators.6-5-2-title
 indicator_sort_order: 06-05-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '6'
 source_active_1: true
 source_organisation_1: sources.Ministry of Nature Protection of RA
-target: global_targets.6-5.title
+target: global_targets.6-5-title
 target_id: '6.5'
 un_custodian_agency: United Nations Education and Scientific Cultural Organisation
   - Institute for Statistics (UNESCO-UIS) United Nations Economic Commission for Europe

--- a/meta/6-6-1.md
+++ b/meta/6-6-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: global_indicators.6-6-1.title
+graph_title: global_indicators.6-6-1-title
 graph_type: line
 indicator: 6.6.1
-indicator_name: global_indicators.6-6-1.title
+indicator_name: global_indicators.6-6-1-title
 indicator_sort_order: 06-06-01
 layout: indicator
 permalink: /6-6-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: global_targets.6-6.title
+target: global_targets.6-6-title
 target_id: '6.6'
 un_custodian_agency: UNEP
 un_designated_tier: '3'

--- a/meta/6-a-1.md
+++ b/meta/6-a-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 398
   KB)
-graph_title: global_indicators.6-a-1.title
+graph_title: global_indicators.6-a-1-title
 graph_type: line
 indicator: 6.a.1
 indicator_definition: The amount of water and sanitation-related Official Development
@@ -13,14 +13,14 @@ indicator_definition: The amount of water and sanitation-related Official Develo
   to gain a better understanding of whether donors are aligned with national governments
   while highlighting total water and sanitation ODA disbursements to developing countries
   over time.
-indicator_name: global_indicators.6-a-1.title
+indicator_name: global_indicators.6-a-1-title
 indicator_sort_order: 06-aa-01
 layout: indicator
 permalink: /6-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: global_targets.6-a.title
+target: global_targets.6-a-title
 target_id: 6.a
 un_custodian_agency: World Health Organization (WHO) United Nations Environment Programme
   (UNEP) Organisation for Economic Co-operation and Development (OECD)

--- a/meta/6-b-1.md
+++ b/meta/6-b-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
-graph_title: global_indicators.6-b-1.title
+graph_title: global_indicators.6-b-1-title
 graph_type: line
 indicator: 6.b.1
-indicator_name: global_indicators.6-b-1.title
+indicator_name: global_indicators.6-b-1-title
 indicator_sort_order: 06-bb-01
 layout: indicator
 permalink: /6-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '6'
-target: global_targets.6-b.title
+target: global_targets.6-b-title
 target_id: 6.b
 un_custodian_agency: WHO,UNEP, OECD
 un_designated_tier: '1'

--- a/meta/7-1-1.md
+++ b/meta/7-1-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 212
   KB)
-graph_title: global_indicators.7-1-1.title
+graph_title: global_indicators.7-1-1-title
 graph_type: line
 indicator: 7.1.1
-indicator_name: global_indicators.7-1-1.title
+indicator_name: global_indicators.7-1-1-title
 indicator_sort_order: 07-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.7-1.title
+target: global_targets.7-1-title
 target_id: '7.1'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/7-1-2.md
+++ b/meta/7-1-2.md
@@ -4,7 +4,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-07-01-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 232
   KB)
-graph_title: global_indicators.7-1-2.title
+graph_title: global_indicators.7-1-2-title
 graph_type: line
 indicator: 7.1.2
 indicator_definition: 'Proportion of population with primary reliance on clean fuels
@@ -14,7 +14,7 @@ indicator_definition: 'Proportion of population with primary reliance on clean f
   emission rate targets and specific fuel recommendations (i.e. against unprocessed
   coal and kerosene) included in the normative guidance WHO guidelines for indoor
   air quality: household fuel combustion.'
-indicator_name: global_indicators.7-1-2.title
+indicator_name: global_indicators.7-1-2-title
 indicator_sort_order: 07-01-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -26,7 +26,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.7-1.title
+target: global_targets.7-1-title
 target_id: '7.1'
 un_custodian_agency: International Trade Centre (ITC) United Nations Conference on
   Trade and Development (UNCTAD) The World Trade Organization (WTO)

--- a/meta/7-2-1.md
+++ b/meta/7-2-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-07-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 216
   KB)
-graph_title: global_indicators.7-2-1.title
+graph_title: global_indicators.7-2-1-title
 graph_type: line
 indicator: 7.2.1
-indicator_name: global_indicators.7-2-1.title
+indicator_name: global_indicators.7-2-1-title
 indicator_sort_order: 07-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '7'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.7-2.title
+target: global_targets.7-2-title
 target_id: '7.2'
 un_custodian_agency: International Energy Agency (IEA) United Nations Statistics Division
   (UNSD) United Nations' inter-agency mechanism on energy (UN Energy) and the SE4ALL

--- a/meta/7-3-1.md
+++ b/meta/7-3-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 192
   KB)
-graph_title: global_indicators.7-3-1.title
+graph_title: global_indicators.7-3-1-title
 graph_type: line
 indicator: 7.3.1
-indicator_name: global_indicators.7-3-1.title
+indicator_name: global_indicators.7-3-1-title
 indicator_sort_order: 07-03-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '7'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.7-3.title
+target: global_targets.7-3-title
 target_id: '7.3'
 un_custodian_agency: International Energy Agency (IEA) United Nations Statistics Division
   (UNSD) United Nations' inter-agency mechanism on energy (UN Energy) and the SE4ALL

--- a/meta/7-a-1.md
+++ b/meta/7-a-1.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-7.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 111
   KB)
-graph_title: global_indicators.7-a-1.title
+graph_title: global_indicators.7-a-1-title
 graph_type: line
 indicator: 7.a.1
 indicator_definition: Mobilized amount of United States dollars per year starting
   in 2020 accountable towards the $100 billion commitment.
-indicator_name: global_indicators.7-a-1.title
+indicator_name: global_indicators.7-a-1-title
 indicator_sort_order: 07-aa-01
 layout: indicator
 permalink: /7-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: global_targets.7-a.title
+target: global_targets.7-a-title
 target_id: 7.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '2'

--- a/meta/7-b-1.md
+++ b/meta/7-b-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-7.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.7-b-1.title
+graph_title: global_indicators.7-b-1-title
 graph_type: line
 indicator: 7.b.1
-indicator_name: global_indicators.7-b-1.title
+indicator_name: global_indicators.7-b-1-title
 indicator_sort_order: 07-bb-01
 layout: indicator
 permalink: /7-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '7'
-target: global_targets.7-b.title
+target: global_targets.7-b-title
 target_id: 7.b
 un_custodian_agency: International Energy Agency (IEA)
 un_designated_tier: '3'

--- a/meta/8-1-1.md
+++ b/meta/8-1-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-01-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 232
   KB)
-graph_title: global_indicators.8-1-1.title
+graph_title: global_indicators.8-1-1-title
 graph_type: line
 indicator: 8.1.1
-indicator_name: global_indicators.8-1-1.title
+indicator_name: global_indicators.8-1-1-title
 indicator_sort_order: 08-01-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.8-1.title
+target: global_targets.8-1-title
 target_id: '8.1'
 un_custodian_agency: United Nations Statistics Division (UNSD)
 un_designated_tier: '1'

--- a/meta/8-10-1.md
+++ b/meta/8-10-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
-graph_title: global_indicators.8-10-1.title
+graph_title: global_indicators.8-10-1-title
 graph_type: line
 indicator: 8.10.1
-indicator_name: global_indicators.8-10-1.title
+indicator_name: global_indicators.8-10-1-title
 indicator_sort_order: 08-10-01
 layout: indicator
 permalink: /8-10-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-10.title
+target: global_targets.8-10-title
 target_id: '8.10'
 un_custodian_agency: IMF
 un_designated_tier: '1'

--- a/meta/8-10-2.md
+++ b/meta/8-10-2.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)
-graph_title: global_indicators.8-10-2.title
+graph_title: global_indicators.8-10-2-title
 graph_type: line
 indicator: 8.10.2
-indicator_name: global_indicators.8-10-2.title
+indicator_name: global_indicators.8-10-2-title
 indicator_sort_order: 08-10-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.DHS
-target: global_targets.8-1.title
+target: global_targets.8-1-title
 target_id: '8.10'
 un_custodian_agency: World Bank (WB)
 un_designated_tier: '1'

--- a/meta/8-2-1.md
+++ b/meta/8-2-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 384
   KB)
-graph_title: global_indicators.8-2-1.title
+graph_title: global_indicators.8-2-1-title
 graph_type: line
 indicator: 8.2.1
-indicator_name: global_indicators.8-2-1.title
+indicator_name: global_indicators.8-2-1-title
 indicator_sort_order: 08-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.8-2.title
+target: global_targets.8-2-title
 target_id: '8.2'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-3-1.md
+++ b/meta/8-3-1.md
@@ -3,10 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 231
   KB)
-graph_title: global_indicators.8-3-1.title
+graph_title: global_indicators.8-3-1-title
 graph_type: line
 indicator: 8.3.1
-indicator_name: global_indicators.8-3-1.title
+indicator_name: global_indicators.8-3-1-title
 indicator_sort_order: 08-03-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.LFS
-target: global_targets.8-3.title
+target: global_targets.8-3-title
 target_id: '8.3'
 un_custodian_agency: International Labour Organisation (ILO)
 un_designated_tier: '2'

--- a/meta/8-4-1.md
+++ b/meta/8-4-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.8-4-1.title
+graph_title: global_indicators.8-4-1-title
 graph_type: line
 indicator: 8.4.1
-indicator_name: global_indicators.8-4-1.title
+indicator_name: global_indicators.8-4-1-title
 indicator_sort_order: 08-04-01
 layout: indicator
 permalink: /8-4-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-4.title
+target: global_targets.8-4-title
 target_id: '8.4'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '3'

--- a/meta/8-4-2.md
+++ b/meta/8-4-2.md
@@ -3,10 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 58.7
   KB)
-graph_title: global_indicators.8-4-2.title
+graph_title: global_indicators.8-4-2-title
 graph_type: line
 indicator: 8.4.2
-indicator_name: global_indicators.8-4-2.title
+indicator_name: global_indicators.8-4-2-title
 indicator_sort_order: 08-04-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.8-4.title
+target: global_targets.8-4-title
 target_id: '8.4'
 un_custodian_agency: United Nations Environment Programme (UNEP)
 un_designated_tier: '1'

--- a/meta/8-5-1.md
+++ b/meta/8-5-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 317
   KB)
-graph_title: global_indicators.8-5-1.title
+graph_title: global_indicators.8-5-1-title
 graph_type: line
 indicator: 8.5.1
-indicator_name: global_indicators.8-5-1.title
+indicator_name: global_indicators.8-5-1-title
 indicator_sort_order: 08-05-01
 layout: indicator
 permalink: /8-5-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-5.title
+target: global_targets.8-5-title
 target_id: '8.5'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: 2

--- a/meta/8-5-2.md
+++ b/meta/8-5-2.md
@@ -4,7 +4,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-05-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 383
   KB)
-graph_title: global_indicators.8-5-2.title
+graph_title: global_indicators.8-5-2-title
 graph_type: line
 indicator: 8.5.2
 indicator_definition: The unemployment rate is a useful measure of the underutilization
@@ -17,7 +17,7 @@ indicator_definition: The unemployment rate is a useful measure of the underutil
   often coincide with recessionary periods or in some cases with the beginning of
   an expansionary period as persons previously not in the labour market begin to test
   conditions through an active job search.
-indicator_name: global_indicators.8-5-2.title
+indicator_name: global_indicators.8-5-2-title
 indicator_sort_order: 08-05-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -27,7 +27,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.8-5.title
+target: global_targets.8-5-title
 target_id: '8.5'
 un_custodian_agency: International labour organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-6-1.md
+++ b/meta/8-6-1.md
@@ -4,14 +4,14 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
   KB)
-graph_title: global_indicators.8-6-1.title
+graph_title: global_indicators.8-6-1-title
 graph_type: line
 indicator: 8.6.1
 indicator_definition: This proportion of youth (aged 15-24 years) not in education,
   employment or training, also known as "the NEET rate", conveys the number of young
   persons not in education, employment or training as a percentage of the total youth
   population.
-indicator_name: global_indicators.8-6-1.title
+indicator_name: global_indicators.8-6-1-title
 indicator_sort_order: 08-06-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -23,7 +23,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.LFS
-target: global_targets.8-6.title
+target: global_targets.8-6-title
 target_id: '8.6'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '1'

--- a/meta/8-7-1.md
+++ b/meta/8-7-1.md
@@ -3,10 +3,10 @@ computation_units: data.number
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-07-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
-graph_title: global_indicators.8-7-1.title
+graph_title: global_indicators.8-7-1-title
 graph_type: line
 indicator: 8.7.1
-indicator_name: global_indicators.8-7-1.title
+indicator_name: global_indicators.8-7-1-title
 indicator_sort_order: 08-07-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -18,7 +18,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Armenia National Child Labour Survey 2015
-target: global_targets.8-7.title
+target: global_targets.8-7-title
 target_id: '8.7'
 un_custodian_agency: ILO,UNICEF
 un_designated_tier: '2'

--- a/meta/8-8-1.md
+++ b/meta/8-8-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-08-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 381
   KB)
-graph_title: global_indicators.8-8-1.title
+graph_title: global_indicators.8-8-1-title
 graph_type: line
 indicator: 8.8.1
-indicator_name: global_indicators.8-8-1.title
+indicator_name: global_indicators.8-8-1-title
 indicator_sort_order: 08-08-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '8'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.8-8.title
+target: global_targets.8-8-title
 target_id: '8.8'
 un_custodian_agency: International Labour Organization (ILO)
 un_designated_tier: '2'

--- a/meta/8-8-2.md
+++ b/meta/8-8-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
-graph_title: global_indicators.8-8-2.title
+graph_title: global_indicators.8-8-2-title
 graph_type: line
 indicator: 8.8.2
-indicator_name: global_indicators.8-8-2.title
+indicator_name: global_indicators.8-8-2-title
 indicator_sort_order: 08-08-02
 layout: indicator
 permalink: /8-8-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-8.title
+target: global_targets.8-8-title
 target_id: '8.8'
 un_custodian_agency: ILO
 un_designated_tier: '3'

--- a/meta/8-9-1.md
+++ b/meta/8-9-1.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 526
   KB)
-graph_title: global_indicators.8-9-1.title
+graph_title: global_indicators.8-9-1-title
 graph_type: line
 indicator: 8.9.1
 indicator_definition: Tourism direct GDP as a proportion of total GDP and in growth
   rate
-indicator_name: global_indicators.8-9-1.title
+indicator_name: global_indicators.8-9-1-title
 indicator_sort_order: 08-09-01
 layout: indicator
 permalink: /8-9-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-9.title
+target: global_targets.8-9-title
 target_id: '8.9'
 un_custodian_agency: World Tourism Organization (UNTWO)
 un_designated_tier: '2'

--- a/meta/8-9-2.md
+++ b/meta/8-9-2.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 526
   KB)
-graph_title: global_indicators.8-9-2.title
+graph_title: global_indicators.8-9-2-title
 graph_type: line
 indicator: 8.9.2
-indicator_name: global_indicators.8-9-2.title
+indicator_name: global_indicators.8-9-2-title
 indicator_sort_order: 08-09-02
 layout: indicator
 permalink: /8-9-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-9.title
+target: global_targets.8-9-title
 target_id: '8.9'
 un_custodian_agency: World Health Organisation (WHO)
 un_designated_tier: '3'

--- a/meta/8-a-1.md
+++ b/meta/8-a-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208
   KB)
-graph_title: global_indicators.8-a-1.title
+graph_title: global_indicators.8-a-1-title
 graph_type: line
 indicator: 8.a.1
-indicator_name: global_indicators.8-a-1.title
+indicator_name: global_indicators.8-a-1-title
 indicator_sort_order: 08-aa-01
 layout: indicator
 permalink: /8-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-a.title
+target: global_targets.8-a-title
 target_id: 8.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/8-b-1.md
+++ b/meta/8-b-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
-graph_title: global_indicators.8-b-1.title
+graph_title: global_indicators.8-b-1-title
 graph_type: line
 indicator: 8.b.1
-indicator_name: global_indicators.8-b-1.title
+indicator_name: global_indicators.8-b-1-title
 indicator_sort_order: 08-bb-01
 layout: indicator
 permalink: /8-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '8'
-target: global_targets.8-b.title
+target: global_targets.8-b-title
 target_id: 8.b
 un_custodian_agency: ILO
 un_designated_tier: '3'

--- a/meta/9-1-1.md
+++ b/meta/9-1-1.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)
-graph_title: global_indicators.9-1-1.title
+graph_title: global_indicators.9-1-1-title
 graph_type: line
 indicator: 9.1.1
-indicator_name: global_indicators.9-1-1.title
+indicator_name: global_indicators.9-1-1-title
 indicator_sort_order: 09-01-01
 layout: indicator
 permalink: /9-1-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: global_targets.9-1.title
+target: global_targets.9-1-title
 target_id: '9.1'
 un_custodian_agency: World Bank
 un_designated_tier: '3'

--- a/meta/9-1-2.md
+++ b/meta/9-1-2.md
@@ -3,10 +3,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 375
   KB)
-graph_title: global_indicators.9-1-2.title
+graph_title: global_indicators.9-1-2-title
 graph_type: line
 indicator: 9.1.2
-indicator_name: global_indicators.9-1-2.title
+indicator_name: global_indicators.9-1-2-title
 indicator_sort_order: 09-01-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.9-1.title
+target: global_targets.9-1-title
 target_id: '9.1'
 un_custodian_agency: International Civil Aviation Organization (ICAO)
 un_designated_tier: '1'

--- a/meta/9-2-1.md
+++ b/meta/9-2-1.md
@@ -3,7 +3,7 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 217
   KB)
-graph_title: global_indicators.9-2-1.title
+graph_title: global_indicators.9-2-1-title
 graph_type: line
 indicator: 9.2.1
 indicator_definition: Manufacturing value added (MVA) is the total value of goods
@@ -12,7 +12,7 @@ indicator_definition: Manufacturing value added (MVA) is the total value of good
   period. It can be presented in percentage to gross domestic product (GDP) as well
   as per capita for any reference year. MVA growth rates are given at constant prices
   (in Chained Volume Measures [CVM]).
-indicator_name: global_indicators.9-2-1.title
+indicator_name: global_indicators.9-2-1-title
 indicator_sort_order: 09-02-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -20,7 +20,7 @@ permalink: /9-2-1/
 published: true
 reporting_status: complete
 sdg_goal: '9'
-target: global_targets.9-2.title
+target: global_targets.9-2-title
 target_id: '9.2'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-2-2.md
+++ b/meta/9-2-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 323
   KB)
-graph_title: global_indicators.9-2-2.title
+graph_title: global_indicators.9-2-2-title
 graph_type: line
 indicator: 9.2.2
-indicator_name: global_indicators.9-2-2.title
+indicator_name: global_indicators.9-2-2-title
 indicator_sort_order: 09-02-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.LFS
-target: global_targets.9-2.title
+target: global_targets.9-2-title
 target_id: '9.2'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
-graph_title: global_indicators.9-3-1.title
+graph_title: global_indicators.9-3-1-title
 graph_type: line
 indicator: 9.3.1
-indicator_name: global_indicators.9-3-1.title
+indicator_name: global_indicators.9-3-1-title
 indicator_sort_order: 09-03-01
 layout: indicator
 permalink: /9-3-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: global_targets.9-3.title
+target: global_targets.9-3-title
 target_id: '9.3'
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '2'

--- a/meta/9-3-2.md
+++ b/meta/9-3-2.md
@@ -2,17 +2,17 @@
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)
-graph_title: global_indicators.9-3-2.title
+graph_title: global_indicators.9-3-2-title
 graph_type: line
 indicator: 9.3.2
-indicator_name: global_indicators.9-3-2.title
+indicator_name: global_indicators.9-3-2-title
 indicator_sort_order: 09-03-02
 layout: indicator
 permalink: /9-3-2/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: global_targets.9-3.title
+target: global_targets.9-3-title
 target_id: '9.3'
 un_custodian_agency: UNIDO,World Bank
 un_designated_tier: '2'

--- a/meta/9-4-1.md
+++ b/meta/9-4-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 516
   KB)
-graph_title: global_indicators.9-4-1.title
+graph_title: global_indicators.9-4-1-title
 graph_type: line
 indicator: 9.4.1
-indicator_name: global_indicators.9-4-1.title
+indicator_name: global_indicators.9-4-1-title
 indicator_sort_order: 09-04-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -19,7 +19,7 @@ source_active_1: true
 source_active_2: true
 source_organisation_1: sources.Armstat
 source_organisation_2: sources.Ministry of Nature Protection of RA
-target: global_targets.9-4.title
+target: global_targets.9-4-title
 target_id: '9.4'
 un_custodian_agency: International Energy Agency (IEA) United Nations Industrial Development
   Organization (UNIDO)

--- a/meta/9-5-1.md
+++ b/meta/9-5-1.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
   KB)
-graph_title: global_indicators.9-5-1.title
+graph_title: global_indicators.9-5-1-title
 graph_type: line
 indicator: 9.5.1
-indicator_name: global_indicators.9-5-1.title
+indicator_name: global_indicators.9-5-1-title
 indicator_sort_order: 09-05-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.9-5.title
+target: global_targets.9-5-title
 target_id: '9.5'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/9-5-2.md
+++ b/meta/9-5-2.md
@@ -4,10 +4,10 @@ data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
   KB)
-graph_title: global_indicators.9-5-2.title
+graph_title: global_indicators.9-5-2-title
 graph_type: line
 indicator: 9.5.2
-indicator_name: global_indicators.9-5-2.title
+indicator_name: global_indicators.9-5-2-title
 indicator_sort_order: 09-05-02
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -17,7 +17,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.9-5.title
+target: global_targets.9-5-title
 target_id: '9.5'
 un_custodian_agency: United Nations Educational Scientific and Cultural Organization
   (UNESCO)

--- a/meta/9-a-1.md
+++ b/meta/9-a-1.md
@@ -3,19 +3,19 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208
   KB)
-graph_title: global_indicators.9-a-1.title
+graph_title: global_indicators.9-a-1-title
 graph_type: line
 indicator: 9.a.1
 indicator_definition: Total resource flows for infrastructure, comprising Official
   Development Assistance (ODA), other official flows (OOF) and private flows
-indicator_name: global_indicators.9-a-1.title
+indicator_name: global_indicators.9-a-1-title
 indicator_sort_order: 09-aa-01
 layout: indicator
 permalink: /9-a-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: global_targets.9-a.title
+target: global_targets.9-a-title
 target_id: 9.a
 un_custodian_agency: Organisation for Economic Co-operation and Development (OECD)
 un_designated_tier: '1'

--- a/meta/9-b-1.md
+++ b/meta/9-b-1.md
@@ -3,17 +3,17 @@ data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-0B-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 332
   KB)
-graph_title: global_indicators.9-b-1.title
+graph_title: global_indicators.9-b-1-title
 graph_type: line
 indicator: 9.b.1
-indicator_name: global_indicators.9-b-1.title
+indicator_name: global_indicators.9-b-1-title
 indicator_sort_order: 09-bb-01
 layout: indicator
 permalink: /9-b-1/
 published: true
 reporting_status: notstarted
 sdg_goal: '9'
-target: global_targets.9-b.title
+target: global_targets.9-b-title
 target_id: 9.b
 un_custodian_agency: United Nations Industrial Development Organization (UNIDO)
 un_designated_tier: '1'

--- a/meta/9-c-1.md
+++ b/meta/9-c-1.md
@@ -3,10 +3,10 @@ computation_units: '%'
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)
-graph_title: global_indicators.9-c-1.title
+graph_title: global_indicators.9-c-1-title
 graph_type: line
 indicator: 9.c.1
-indicator_name: global_indicators.9-c-1.title
+indicator_name: global_indicators.9-c-1-title
 indicator_sort_order: 09-cc-01
 layout: indicator
 national_geographical_coverage: custom.armenia
@@ -16,7 +16,7 @@ reporting_status: complete
 sdg_goal: '9'
 source_active_1: true
 source_organisation_1: sources.Armstat
-target: global_targets.9-c.title
+target: global_targets.9-c-title
 target_id: 9.c
 un_custodian_agency: ITU
 un_designated_tier: '1'


### PR DESCRIPTION
This should fix the problem with the global indicator names.